### PR TITLE
fix: make MCP context response JSON-serializable with LLM formatting

### DIFF
--- a/scripts/bench_h2h_predict.py
+++ b/scripts/bench_h2h_predict.py
@@ -898,6 +898,8 @@ def _daemon_response_to_stdout(category: str, response: dict[str, Any]) -> str:
         # Daemon returns {"status":"ok","result":{"entry_point":...,"functions":[...]}}.
         # Unwrap inner "result" so the context parser sees the shape it expects.
         inner = response.get("result", {})
+        if isinstance(inner, str):
+            return inner
         if isinstance(inner, dict):
             return json.dumps(inner)
         return json.dumps(response)

--- a/tests/test_mcp_context_serialization.py
+++ b/tests/test_mcp_context_serialization.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from tldr.api import FunctionContext, RelevantContext
+from tldr.daemon.cached_queries import cached_context
+from tldr.salsa import SalsaDB
+
+
+def test_cached_context_returns_llm_string_not_dict_repr() -> None:
+    fake_context = RelevantContext(
+        entry_point="pkg.auth.login",
+        depth=2,
+        functions=[
+            FunctionContext(
+                name="pkg.auth.login",
+                file="pkg/auth.py",
+                line=42,
+                signature="def login(user, password):",
+                docstring="Authenticate a user.",
+                calls=["pkg.auth.validate"],
+            )
+        ],
+    )
+
+    with patch("tldr.api.get_relevant_context", return_value=fake_context):
+        response = cached_context(
+            SalsaDB(),
+            project=".",
+            entry="pkg.auth.login",
+            language="python",
+            depth=2,
+            ignore_spec=None,
+            workspace_root=None,
+        )
+
+    assert response["status"] == "ok"
+    assert isinstance(response["result"], str)
+    assert "Code Context" in response["result"]
+    assert "'entry_point'" not in response["result"]
+    json.dumps(response)

--- a/tldr/daemon/cached_queries.py
+++ b/tldr/daemon/cached_queries.py
@@ -5,7 +5,6 @@ These functions wrap the TLDR API with automatic caching via SalsaDB.
 Results are memoized and automatically invalidated when source files change.
 """
 
-from dataclasses import asdict
 from pathlib import Path
 
 from tldr.salsa import SalsaDB, salsa_query
@@ -154,7 +153,7 @@ def cached_context(
         ignore_spec=ignore_spec,
         workspace_root=workspace_root,
     )
-    return {"status": "ok", "result": asdict(result)}
+    return {"status": "ok", "result": result.to_llm_string()}
 
 
 @salsa_query


### PR DESCRIPTION
## Summary

- **Fix quality bug**: `cached_context()` in `tldr/daemon/cached_queries.py` now calls `result.to_llm_string()` instead of `asdict(result)`, so the MCP server receives a pre-formatted LLM-ready markdown string rather than a plain dict that falls through to ugly `str(ctx)` repr
- **Benchmark compatibility**: `scripts/bench_h2h_predict.py` daemon response adapter now handles string results with an early `isinstance(inner, str): return inner` guard
- **Regression test**: New `tests/test_mcp_context_serialization.py` verifies the response is a JSON-serializable string containing formatted markdown (not Python dict repr)

## The Problem

The MCP `context` tool was silently returning garbage to LLMs.

**The data flow:**

```
cached_context() returns {"result": asdict(result)}  →  a dict
     ↓
daemon serializes via json.dumps() over socket
     ↓
MCP server deserializes via json.loads()  →  still a plain dict
     ↓
mcp_server.py:307 checks hasattr(ctx, "to_llm_string")  →  False (dicts don't have methods)
     ↓
Falls through to str(ctx)  →  Python dict repr
```

So when an LLM called the `context` MCP tool, it received:

```
{'entry_point': 'main', 'depth': 2, 'functions': [{'name': 'main', 'file': '/tmp/app.py',
'line': 1, 'signature': 'def main()', 'docstring': None, 'calls': ['helper'], 'blocks': 1,
'cyclomatic': 1}]}
```

Instead of the intended clean markdown:

```
## Code Context: main (depth=2)

📍 main (app.py:1)
   def main()
   → calls: helper

---
1 functions | ~25 tokens
```

## Impact if Left Unfixed

**Token waste.** The dict repr is verbose — it includes every field name (`'name'`, `'file'`, `'line'`, `'signature'`, `'docstring'`, `'calls'`, `'blocks'`, `'cyclomatic'`) repeated per function, plus `None` values. The `to_llm_string()` output is ~40-60% smaller for the same information. For a depth-2 context query returning 10 functions, that's hundreds of wasted tokens per call.

**Degraded LLM comprehension.** LLMs parse markdown headers, indentation, and semantic markers (`📍`, `→ calls:`) far better than nested Python dict literals with single-quoted keys. The model has to waste reasoning capacity parsing `{'entry_point': 'main', 'depth': 2, 'functions': [{'name':...` instead of immediately seeing the call graph structure.

**Silent failure.** No error, no crash, no log — it just quietly returned garbage. The `context` tool's docstring promises "LLM-ready formatted context string" and its return type is `-> str`. It was technically returning a string... just `str(dict)`. Anyone using the MCP server would assume the tool worked correctly and never know they were getting degraded output.

**The CLI worked fine.** `tldr context main --project .` calls `ctx.to_llm_string()` directly at `cli.py:1338`, bypassing the daemon entirely. So manual testing would never reveal the bug — only MCP consumers (the primary use case for AI tool integration) were affected.

**Benchmark scoring.** The `bench_h2h_predict.py` context adapter was built around the dict format, so benchmark scores for the `context` category were valid. But they were measuring the wrong thing — they scored structured dict extraction accuracy rather than the actual MCP output quality that LLMs receive.

In short: the tool that's supposed to save 95% of tokens was silently delivering its output in the worst possible format to every LLM consumer.

## The Fix

Call `result.to_llm_string()` *before* the JSON serialization boundary so the string survives the socket round-trip intact. `str()` on a string is a no-op, so the MCP server returns it cleanly.

The benchmark script `scripts/bench_h2h_predict.py` had a context adapter that unwrapped `result` assuming it was a dict. Added a passthrough for when it's already a string — the existing text-mode parser (which parses `📍 func_name (file.py:42)` lines) handles it correctly.

## Context

Ports and adapts upstream parcadei/llm-tldr#51 ("fix: make MCP context response JSON-serializable") to our fork. While our fork already avoided the upstream crash (raw dataclass not JSON-serializable) by using `asdict()`, the MCP server at `mcp_server.py:307` checks `hasattr(ctx, "to_llm_string")` on the deserialized result — a plain dict never has that method, so it fell through to `str(ctx)`, producing ugly Python dict repr instead of clean LLM-formatted markdown.

### Analysis methodology

Three models were spawned in parallel to independently analyze the upstream PR:
- **Gemini 3.1 Pro** (via `gemini` CLI)
- **OpenAI Codex 5.3 xhigh** (via `codex exec` with disk-full-read-access sandbox)
- **Claude Opus 4.6** (via Agent subagent)

All three unanimously recommended adopting `to_llm_string()`. Codex uniquely identified the benchmark adapter compatibility issue by live-testing the code paths.

## Files changed

| File | Change |
|------|--------|
| `tldr/daemon/cached_queries.py` | `asdict(result)` → `result.to_llm_string()`; removed unused `asdict` import |
| `scripts/bench_h2h_predict.py` | Added string passthrough in `_daemon_response_to_stdout` |
| `tests/test_mcp_context_serialization.py` | New regression test |

## Test plan

- [x] Full test suite passes: `uv run pytest tests/ -v --tb=short` (543 passed)
- [x] New regression test `test_cached_context_returns_llm_string_not_dict_repr` validates:
  - `response["result"]` is a `str` (not dict)
  - Contains "Code Context" header
  - No Python dict repr keys (`'entry_point'`)
  - JSON-serializable via `json.dumps()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)