### PR TITLE
Add opt-in Jina semantic support and publish benchmark-backed usage guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ The daemon keeps indexes in memory for **100ms queries** instead of 30-second CL
 │  │   L1    │ │   L2    │ │   L3    │ │   L4    │ │   L5    │     │
 │  └─────────┘ └─────────┘ └─────────┘ └─────────┘ └─────────┘     │
 └───────────────────────────┬──────────────────────────────────────┘
-                            │ bge-large-en-v1.5
+                            │ bge-large-en-v1.5 / jina-code-0.5b
                             ▼
 ┌──────────────────────────────────────────────────────────────────┐
 │                    SEMANTIC INDEX                                │
-│  1024-dim embeddings in FAISS  →  "find JWT validation"          │
+│  Model-specific embeddings in FAISS  →  "find JWT validation"    │
 └───────────────────────────┬──────────────────────────────────────┘
                             │
                             ▼
@@ -89,7 +89,7 @@ Every function gets indexed with:
 - Dependencies (L5)
 - First ~10 lines of actual code
 
-This gets encoded into **1024-dimensional vectors** using `bge-large-en-v1.5`. The result: search by *what code does*, not just what it says.
+By default this gets encoded into **1024-dimensional vectors** using `bge-large-en-v1.5`. You can also opt into `jina-code-0.5b` for code-focused embeddings, but that requires a full semantic reindex because the embedding dimension changes to 896.
 
 ```bash
 # "validate JWT" finds verify_access_token() even without that exact text
@@ -109,6 +109,15 @@ tldrf semantic "database connection pooling" .
 ```
 
 Embedding dependencies (`sentence-transformers`, `faiss-cpu`) are included with `pip install llm-tldr`. The semantic index is cached under your `cache_root` in `.tldr/` (see below).
+
+Opt-in model selection:
+
+```bash
+# Keep BGE as the default unless you explicitly switch models
+tldrf semantic index . --model jina-code-0.5b --rebuild
+```
+
+Switching between `bge-large-en-v1.5`, `jina-code-0.5b`, and `all-MiniLM-L6-v2` requires rebuilding semantic artifacts for that index id. `jina-code-0.5b` also carries a non-commercial license caveat unless you have a separate commercial license.
 
 ### Where TLDR Stores Things
 
@@ -447,7 +456,8 @@ Create `.tldr/config.json` for daemon settings:
 {
   "semantic": {
     "enabled": true,
-    "auto_reindex_threshold": 20
+    "auto_reindex_threshold": 20,
+    "model": "bge-large-en-v1.5"
   }
 }
 ```
@@ -456,6 +466,7 @@ Create `.tldr/config.json` for daemon settings:
 |---------|---------|-------------|
 | `enabled` | `true` | Enable semantic search |
 | `auto_reindex_threshold` | `20` | Files changed before auto-rebuild |
+| `model` | `bge-large-en-v1.5` | Embedding model for daemon-triggered semantic indexing (`jina-code-0.5b` is opt-in and requires rebuild) |
 
 ### Monorepo Support
 
@@ -501,6 +512,8 @@ Open-ended judge-mode snapshot (Codex answers, Claude judge; `--trials 3`):
 ## Deep Dive
 
 For the full architecture explanation, benchmarks, and advanced workflows:
+
+**[One-Page Usage Guide](./docs/llm-tldr-reference-card.md)**
 
 **[Full Documentation](./docs/TLDR.md)**
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,39 @@ tldrf semantic index . --model jina-code-0.5b --rebuild
 
 Switching between `bge-large-en-v1.5`, `jina-code-0.5b`, and `all-MiniLM-L6-v2` requires rebuilding semantic artifacts for that index id. `jina-code-0.5b` also carries a non-commercial license caveat unless you have a separate commercial license.
 
+### Why This Helps Smaller Models
+
+In theory and in practice, yes. A tool like `tldrf` should help smaller or less capable models more than it helps frontier models, because it shifts work from “infer the codebase from scattered text” to “reason over a smaller, structured evidence set.”
+
+Why that helps:
+- It reduces search-space. The model does not need to mentally reconstruct callers, callees, slices, or data flow from raw files.
+- It preserves context. You pass back compact, targeted outputs instead of whole files and repeated scans.
+- It reduces context pollution. A smaller model is much easier to derail with irrelevant files or nearby-but-wrong matches.
+- It adds determinism. `impact`, `slice`, `dfg`, `cfg`, and structural context are stronger than “the model probably found the right thing.”
+- It amortizes cost. Index once, query many times, instead of forcing the model to rediscover the repo on every turn.
+
+The key distinction is:
+- `rg` is better for exact lexical lookup.
+- `tldrf` is better for concept discovery plus structural follow-up.
+
+That means the best use is usually not “replace `rg`,” but:
+- use `rg` for exact names/strings/imports
+- use hybrid retrieval when you know intent but not the symbol
+- use `impact/context/slice/dfg/cfg` to give the model the exact connected evidence it should reason over
+
+That is especially valuable for smaller models, because they are worse at:
+- planning multi-step codebase exploration
+- keeping long dependency chains in working memory
+- recovering after being shown noisy or partially relevant context
+
+The caveat is important: `tldrf` does not replace reasoning. It improves retrieval and evidence quality. If the retrieval is poor, stale, or too broad, a smaller model can still fail. So the tool only pays off when:
+- indexes are fresh
+- language support is good for the repo
+- you use the right lane for the task
+- you still keep `rg` in the loop for exact checks
+
+So the short answer is: yes, this kind of tool is probably most valuable for smaller models and large codebases, because it turns expensive, lossy exploration into a more deterministic retrieval-and-analysis workflow while saving context for the actual reasoning/editing step.
+
 ### Where TLDR Stores Things
 
 TLDR stores two different kinds of artifacts:

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -159,6 +159,56 @@ Open-ended judge-mode tasks (free-form answers, judged A/B; `--trials 3`):
 | slice_only | 1000 | 7 | **0.548** |  | **0.548** |  | `benchmark/runs/20260210-211226Z-llm-ab-run-judge-slice-1000-t3.json` |
 | slice_only | 500 | 7 | **0.429** |  | **0.429** |  | `benchmark/runs/20260210-212621Z-llm-ab-run-judge-slice-500-t3.json` |
 
+### 2026-03: Model Variant Addendum (BGE Default vs Jina Opt-In)
+
+This is the aggregate decision surface for the 009 migration work. It rolls up the daemon-mode Django runs from `implementations/009-migrate-bge-to-jina-code-0.5b_IMPLEMENTATION_PLAN.md` so readers do not need to reconstruct the decision from implementation logs.
+
+Use it like this:
+- `rg-native` is the lexical baseline for exact lookup.
+- `contextplus` remains the pinned 008 external competitor baseline and was not rerun in the Jina migration.
+- `BGE` is the current llm-tldr default.
+- `Jina` is the opt-in candidate under evaluation.
+
+#### Scenario Decision Guide
+
+| Situation | Best current choice | Why |
+| --- | --- | --- |
+| Exact symbol / definition lookup | `rg-native` | Structured exact-definition retrieval is `F1 0.9841` for `rg-native` vs `0.1602` for BGE and `0.1520` for Jina. |
+| Default product retrieval lane | `llm-tldr` with `BGE` | Jina is roughly tied on common `hybrid_rrf`, but BGE still wins the lane2 gate row, compound efficiency, and structured concept retrieval. |
+| Pure semantic concept lookup | `llm-tldr --model jina-code-0.5b` | Jina is clearly better on pure semantic retrieval quality (`MRR 0.7023` vs `0.6022`). |
+| Budget-limited semantic retrieval | `llm-tldr --model jina-code-0.5b` | At `budget=1000`, Jina improves semantic retrieval (`0.7048` vs `0.6124`) and slightly improves hybrid (`0.8647` vs `0.8597`). |
+| Concept-style retrieval in the current product path | `llm-tldr` with `BGE` | On structured behavior retrieval, BGE beats Jina in both semantic (`F1 0.1458` vs `0.1053`) and hybrid (`F1 0.1584` vs `0.1188`). |
+| Compound "find code and who calls it" | `llm-tldr` with `BGE` | Correctness is tied, but BGE has the better compound efficiency ratio (`1.0250` vs `1.1361`). |
+
+#### Model / Tool Comparison Matrix
+
+Unless noted otherwise, rows below are daemon-mode Django artifacts.
+
+| Surface | `rg-native` / `contextplus` context | `BGE` | `Jina` | Takeaway |
+| --- | --- | --- | --- | --- |
+| Common lane `hybrid_rrf` retrieval quality | `rg-native`: `MRR 0.820`, `R@5 0.877`, `FPR@5 0.000`; `contextplus`: `MRR 0.216`, `R@5 0.298`, `FPR@5 1.000` | `MRR 0.8684`, `R@5 0.9649`, `R@10 1.0000`, `P@5 0.1930` | `MRR 0.8686`, `R@5 0.9825`, `R@10 1.0000`, `P@5 0.1965` | Both llm-tldr models beat the external baselines by a wide margin; Jina only has a marginal edge here. |
+| Common lane `hybrid_lane2` retrieval quality | No direct `rg-native` or `contextplus` lane2 analogue; compare as an intra-tool default gate row | `MRR 0.8741`, `R@5 0.8772`, `R@10 0.9649`, `P@5 0.1754` | `MRR 0.8417`, `R@5 0.9123`, `R@10 1.0000`, `P@5 0.1825` | BGE still wins the canonical default gate on MRR even though Jina gains some recall and precision. |
+| Pure semantic concept retrieval | `contextplus` concept-path parity is still below llm-tldr; `rg-native` is not the right comparator for this row | `MRR 0.6022`, `R@5 0.7719`, `R@10 0.7895`, `P@5 0.1544` | `MRR 0.7023`, `R@5 0.8596`, `R@10 0.8772`, `P@5 0.1719` | This is the main place Jina is genuinely better than BGE. |
+| Token-efficiency retrieval @ `1000` | `rg-native`: `MRR 0.820`, `tok 159.0`; no pinned `contextplus` token curve | `semantic 0.6124`, `hybrid_rrf 0.8597` | `semantic 0.7048`, `hybrid_rrf 0.8647` | Jina wins semantic retrieval under token pressure; the hybrid gain is small. |
+| Compound semantic + impact | No direct `rg-native` / `contextplus` equivalent | `TTE p50 ratio 1.0250`, overlap `1.0`, callers Jaccard `1.0` | `TTE p50 ratio 1.1361`, overlap `1.0`, callers Jaccard `1.0` | Correctness is tied, but Jina makes the compound path less efficient relative to sequential search + impact. |
+| Structured exact-definition retrieval | `rg-native`: `F1 0.9841`, `p50 84.8ms`; `contextplus`: not run on this suite | `F1 0.1602`, `p50 142.1ms` | `F1 0.1520`, `p50 140.3ms` | Exact lookup remains a lexical task; neither embedding model should replace `rg-native` here. |
+| Structured behavior retrieval (semantic) | `rg-native`: `F1 0.0217`, `p50 87.3ms`; `contextplus`: not run on this suite | `F1 0.1458`, `p50 169.5ms` | `F1 0.1053`, `p50 185.9ms` | Semantic retrieval adds real value over `rg-native` for concept-style lookup, but BGE beats Jina. |
+| Structured behavior retrieval (hybrid) | `rg-native`: `F1 0.0217`, `p50 87.3ms`; `contextplus`: not run on this suite | `F1 0.1584`, `p50 422.9ms` | `F1 0.1188`, `p50 438.5ms` | Hybrid helps concept-style lookup, but BGE still wins and the harness includes deterministic file-to-symbol projection overhead. |
+| Structured behavior retrieval (hybrid + `rg_empty`) | Negative query fixed for both; positive hybrid queries were suppressed | `F1 0.0000`, `p50 358.0ms` | `F1 0.0000`, `p50 358.3ms` | Strict lexical guarding is too aggressive for the current behavior-query labels. |
+| Steady-state daemon semantic latency | `rg-native` common-lane p50 is `216.2ms`; `contextplus` remains subprocess-heavy in the pinned 008 comparison (`7717ms`) | `p50 150.2ms`, `p95 250.2ms` | `p50 166.5ms`, `p95 286.4ms` | BGE is still faster at steady-state semantic query time by about `10-14%`. |
+| Semantic build / memory cost | `rg-native` and `contextplus` do not have an equivalent embedding-index build cost | fresh parity rebuild still pending | `build_s 692.57`, `peak_rss 3360.1MB` | Jina is operationally heavier, which is one reason the default did not flip. |
+
+Artifacts referenced above:
+- `benchmark/runs/20260306-103455Z-retrieval-django-jina05b-daemon.json`
+- `benchmark/runs/20260306-103542Z-retrieval-django-jina05b-lane2-daemon.json`
+- `benchmark/runs/20260306-103645Z-token-efficiency-django-jina05b-daemon.json`
+- `benchmark/runs/20260306-103725Z-compound-semantic-impact-django-jina05b-daemon.json`
+- `benchmark/runs/20260306-182147Z-structured-retrieval-django.json`
+- `benchmark/runs/20260306-185707Z-structured-retrieval-django.json`
+- `benchmark/runs/20260306-190233Z-structured-retrieval-django.json`
+- `benchmark/runs/20260306-adhoc-daemon-semantic-latency-bge-vs-jina.json`
+- `benchmark/logs/20260306-101553Z-django-jina05b-semantic.log`
+
 ## Setup
 
 ```bash
@@ -314,7 +364,14 @@ uv run tldrf semantic index --cache-root benchmark/cache-root --index repo:djang
 
 # Higher-quality (default) model (larger download):
 uv run tldrf semantic index --cache-root benchmark/cache-root --index repo:django --lang python --rebuild benchmark/corpora/django
+
+# Opt-in Jina candidate (use a separate index id; rebuild required because dim changes):
+uv run tldrf semantic index --cache-root benchmark/cache-root --index repo:django-jina05b --lang python --model jina-code-0.5b --rebuild benchmark/corpora/django
 ```
+
+Notes:
+- Keep model comparisons on separate `--index` ids (`repo:django-bge15`, `repo:django-jina05b`) so reports stay comparable.
+- `jina-code-0.5b` is opt-in and may require separate license review for commercial use.
 
 ## Phase 5b: Compound Semantic+Impact (Deterministic)
 

--- a/benchmarks/retrieval/django_structured_behavior_queries.json
+++ b/benchmarks/retrieval/django_structured_behavior_queries.json
@@ -1,0 +1,244 @@
+{
+  "schema_version": 1,
+  "repo": "django",
+  "pinned_ref": "5.1.13",
+  "updated": "2026-03-06",
+  "notes": [
+    "Behavior-oriented structured retrieval benchmark for Django.",
+    "Queries avoid exact target symbol names and use broader lexical patterns so semantic retrieval has a fairer chance to outperform native rg on concept lookup.",
+    "Targets still resolve to exact structured code units, so scoring remains deterministic.",
+    "Use this suite as a semantic-leaning cross-tool check; the exact-definition suite remains the stricter lexical sanity check."
+  ],
+  "queries": [
+    {
+      "id": "SB01",
+      "query": "Where does Django implement the middleware that protects against cross-site request forgery?",
+      "rg_pattern": "cross-site request forgery|csrf protection|csrf middleware",
+      "targets": [
+        {
+          "file": "django/middleware/csrf.py",
+          "qualified_symbol": "django.middleware.csrf.py.CsrfViewMiddleware",
+          "symbol_kind": "class",
+          "start_line": 165,
+          "end_line": 165
+        }
+      ]
+    },
+    {
+      "id": "SB02",
+      "query": "Where does Django rotate the CSRF token value for a request?",
+      "rg_pattern": "rotate token|csrf token|CSRF_COOKIE",
+      "targets": [
+        {
+          "file": "django/middleware/csrf.py",
+          "qualified_symbol": "django.middleware.csrf.py.rotate_token",
+          "symbol_kind": "function",
+          "start_line": 117,
+          "end_line": 117
+        }
+      ]
+    },
+    {
+      "id": "SB03",
+      "query": "Where does Django build the detailed debug page for unhandled server exceptions?",
+      "rg_pattern": "technical 500|ExceptionReporter|traceback",
+      "targets": [
+        {
+          "file": "django/views/debug.py",
+          "qualified_symbol": "django.views.debug.py.technical_500_response",
+          "symbol_kind": "function",
+          "start_line": 62,
+          "end_line": 62
+        }
+      ]
+    },
+    {
+      "id": "SB04",
+      "query": "Where does Django turn a form class into a reusable formset class?",
+      "rg_pattern": "form class|formset class|management form",
+      "targets": [
+        {
+          "file": "django/forms/formsets.py",
+          "qualified_symbol": "django.forms.formsets.py.formset_factory",
+          "symbol_kind": "function",
+          "start_line": 534,
+          "end_line": 534
+        }
+      ]
+    },
+    {
+      "id": "SB05",
+      "query": "Where does Django populate settings from defaults and explicit overrides at runtime?",
+      "rg_pattern": "default_settings|manually configured|configured settings",
+      "targets": [
+        {
+          "file": "django/conf/__init__.py",
+          "qualified_symbol": "django.conf.__init__.py.LazySettings.configure",
+          "symbol_kind": "method",
+          "start_line": 111,
+          "end_line": 111
+        }
+      ]
+    },
+    {
+      "id": "SB06",
+      "query": "Where does Django turn a view name into a concrete URL path?",
+      "rg_pattern": "viewname|current_app|URL reversing",
+      "targets": [
+        {
+          "file": "django/urls/base.py",
+          "qualified_symbol": "django.urls.base.py.reverse",
+          "symbol_kind": "function",
+          "start_line": 27,
+          "end_line": 27
+        }
+      ]
+    },
+    {
+      "id": "SB07",
+      "query": "Where does Django render a template directly into an HTTP response?",
+      "rg_pattern": "render_to_string|HttpResponse|content_type",
+      "targets": [
+        {
+          "file": "django/shortcuts.py",
+          "qualified_symbol": "django.shortcuts.py.render",
+          "symbol_kind": "function",
+          "start_line": 18,
+          "end_line": 18
+        }
+      ]
+    },
+    {
+      "id": "SB08",
+      "query": "Where does Django turn a target object or URL into an HTTP redirect response?",
+      "rg_pattern": "resolve_url|HttpResponseRedirect|permanent redirect",
+      "targets": [
+        {
+          "file": "django/shortcuts.py",
+          "qualified_symbol": "django.shortcuts.py.redirect",
+          "symbol_kind": "function",
+          "start_line": 29,
+          "end_line": 29
+        }
+      ]
+    },
+    {
+      "id": "SB09",
+      "query": "Where does Django open an atomic database transaction block?",
+      "rg_pattern": "savepoint|durable|transaction block",
+      "targets": [
+        {
+          "file": "django/db/transaction.py",
+          "qualified_symbol": "django.db.transaction.py.atomic",
+          "symbol_kind": "function",
+          "start_line": 316,
+          "end_line": 316
+        }
+      ]
+    },
+    {
+      "id": "SB10",
+      "query": "Where does Django define the compatibility mixin used by middleware classes?",
+      "rg_pattern": "sync_capable|async_capable|middleware classes",
+      "targets": [
+        {
+          "file": "django/utils/deprecation.py",
+          "qualified_symbol": "django.utils.deprecation.py.MiddlewareMixin",
+          "symbol_kind": "class",
+          "start_line": 95,
+          "end_line": 95
+        }
+      ]
+    },
+    {
+      "id": "SB11",
+      "query": "Where does Django define the base type used for management commands?",
+      "rg_pattern": "missing_args_message|add_arguments|management command",
+      "targets": [
+        {
+          "file": "django/core/management/base.py",
+          "qualified_symbol": "django.core.management.base.py.BaseCommand",
+          "symbol_kind": "class",
+          "start_line": 184,
+          "end_line": 184
+        }
+      ]
+    },
+    {
+      "id": "SB12",
+      "query": "Where does Django dispatch management commands from argv?",
+      "rg_pattern": "ManagementUtility|argv|command line",
+      "targets": [
+        {
+          "file": "django/core/management/__init__.py",
+          "qualified_symbol": "django.core.management.__init__.py.execute_from_command_line",
+          "symbol_kind": "function",
+          "start_line": 439,
+          "end_line": 439
+        }
+      ]
+    },
+    {
+      "id": "SB13",
+      "query": "Where does Django wrap a view so anonymous users are redirected to login?",
+      "rg_pattern": "redirect_to_login|user_passes_test|anonymous users",
+      "targets": [
+        {
+          "file": "django/contrib/auth/decorators.py",
+          "qualified_symbol": "django.contrib.auth.decorators.py.login_required",
+          "symbol_kind": "function",
+          "start_line": 72,
+          "end_line": 72
+        }
+      ]
+    },
+    {
+      "id": "SB14",
+      "query": "Where does Django mark a view so CSRF processing is skipped?",
+      "rg_pattern": "csrf_processing_done|skip csrf|csrf checks",
+      "targets": [
+        {
+          "file": "django/views/decorators/csrf.py",
+          "qualified_symbol": "django.views.decorators.csrf.py.csrf_exempt",
+          "symbol_kind": "function",
+          "start_line": 51,
+          "end_line": 51
+        }
+      ]
+    },
+    {
+      "id": "SB15",
+      "query": "Where does Django mark a string as safe for HTML output?",
+      "rg_pattern": "SafeString|safe html|safe string",
+      "targets": [
+        {
+          "file": "django/utils/safestring.py",
+          "qualified_symbol": "django.utils.safestring.py.mark_safe",
+          "symbol_kind": "function",
+          "start_line": 59,
+          "end_line": 59
+        }
+      ]
+    },
+    {
+      "id": "SB16",
+      "query": "Where does Django implement the chainable ORM query API?",
+      "rg_pattern": "query api|filter\\(|exclude\\(|queryset",
+      "targets": [
+        {
+          "file": "django/db/models/query.py",
+          "qualified_symbol": "django.db.models.query.py.QuerySet",
+          "symbol_kind": "class",
+          "start_line": 293,
+          "end_line": 293
+        }
+      ]
+    },
+    {
+      "id": "SB17",
+      "query": "Negative query: a middleware feature that should not exist in Django",
+      "rg_pattern": "this_nonexistent_behavioral_middleware_abcdef1234",
+      "targets": []
+    }
+  ]
+}

--- a/benchmarks/retrieval/django_structured_queries.json
+++ b/benchmarks/retrieval/django_structured_queries.json
@@ -1,0 +1,455 @@
+{
+  "schema_version": 1,
+  "repo": "django",
+  "pinned_ref": "5.1.13",
+  "updated": "2026-03-06",
+  "notes": [
+    "Definition-oriented structured retrieval benchmark for Django.",
+    "Targets are explicit structured code units so backends are scored on deterministic precision, recall, and F1 rather than file-only relevance.",
+    "The suite intentionally focuses on functions, classes, and methods that map cleanly to llm-tldr semantic units.",
+    "Assignment-like targets such as module-level aliases or signal declarations are excluded from this first pass because semantic units do not currently represent them directly.",
+    "The native rg baseline remains fair because each query ships with an anchored definition pattern that can hit the exact target line without AST heuristics."
+  ],
+  "queries": [
+    {
+      "id": "SR01",
+      "query": "Where is CsrfViewMiddleware implemented?",
+      "rg_pattern": "^class\\s+CsrfViewMiddleware\\b",
+      "targets": [
+        {
+          "file": "django/middleware/csrf.py",
+          "qualified_symbol": "django.middleware.csrf.py.CsrfViewMiddleware",
+          "symbol_kind": "class",
+          "start_line": 165,
+          "end_line": 165
+        }
+      ]
+    },
+    {
+      "id": "SR02",
+      "query": "Where is override_settings implemented?",
+      "rg_pattern": "^class\\s+override_settings\\b",
+      "targets": [
+        {
+          "file": "django/test/utils.py",
+          "qualified_symbol": "django.test.utils.py.override_settings",
+          "symbol_kind": "class",
+          "start_line": 458,
+          "end_line": 458
+        }
+      ]
+    },
+    {
+      "id": "SR03",
+      "query": "Where is mark_safe implemented?",
+      "rg_pattern": "^def\\s+mark_safe\\b",
+      "targets": [
+        {
+          "file": "django/utils/safestring.py",
+          "qualified_symbol": "django.utils.safestring.py.mark_safe",
+          "symbol_kind": "function",
+          "start_line": 59,
+          "end_line": 59
+        }
+      ]
+    },
+    {
+      "id": "SR04",
+      "query": "Where is URLResolver implemented?",
+      "rg_pattern": "^class\\s+URLResolver\\b",
+      "targets": [
+        {
+          "file": "django/urls/resolvers.py",
+          "qualified_symbol": "django.urls.resolvers.py.URLResolver",
+          "symbol_kind": "class",
+          "start_line": 493,
+          "end_line": 493
+        }
+      ]
+    },
+    {
+      "id": "SR05",
+      "query": "Where is ProjectState implemented?",
+      "rg_pattern": "^class\\s+ProjectState\\b",
+      "targets": [
+        {
+          "file": "django/db/migrations/state.py",
+          "qualified_symbol": "django.db.migrations.state.py.ProjectState",
+          "symbol_kind": "class",
+          "start_line": 93,
+          "end_line": 93
+        }
+      ]
+    },
+    {
+      "id": "SR06",
+      "query": "Where is AdminSite implemented?",
+      "rg_pattern": "^class\\s+AdminSite\\b",
+      "targets": [
+        {
+          "file": "django/contrib/admin/sites.py",
+          "qualified_symbol": "django.contrib.admin.sites.py.AdminSite",
+          "symbol_kind": "class",
+          "start_line": 30,
+          "end_line": 30
+        }
+      ]
+    },
+    {
+      "id": "SR07",
+      "query": "Where does LazySettings.configure live?",
+      "rg_pattern": "^\\s+def\\s+configure\\b",
+      "targets": [
+        {
+          "file": "django/conf/__init__.py",
+          "qualified_symbol": "django.conf.__init__.py.LazySettings.configure",
+          "symbol_kind": "method",
+          "start_line": 111,
+          "end_line": 111
+        }
+      ]
+    },
+    {
+      "id": "SR08",
+      "query": "Where is formset_factory implemented?",
+      "rg_pattern": "^def\\s+formset_factory\\b",
+      "targets": [
+        {
+          "file": "django/forms/formsets.py",
+          "qualified_symbol": "django.forms.formsets.py.formset_factory",
+          "symbol_kind": "function",
+          "start_line": 534,
+          "end_line": 534
+        }
+      ]
+    },
+    {
+      "id": "SR09",
+      "query": "Where is technical_500_response implemented?",
+      "rg_pattern": "^def\\s+technical_500_response\\b",
+      "targets": [
+        {
+          "file": "django/views/debug.py",
+          "qualified_symbol": "django.views.debug.py.technical_500_response",
+          "symbol_kind": "function",
+          "start_line": 62,
+          "end_line": 62
+        }
+      ]
+    },
+    {
+      "id": "SR10",
+      "query": "Where is WSGIRequest implemented?",
+      "rg_pattern": "^class\\s+WSGIRequest\\b",
+      "targets": [
+        {
+          "file": "django/core/handlers/wsgi.py",
+          "qualified_symbol": "django.core.handlers.wsgi.py.WSGIRequest",
+          "symbol_kind": "class",
+          "start_line": 56,
+          "end_line": 56
+        }
+      ]
+    },
+    {
+      "id": "SR11",
+      "query": "Where is rotate_token implemented?",
+      "rg_pattern": "^def\\s+rotate_token\\b",
+      "targets": [
+        {
+          "file": "django/middleware/csrf.py",
+          "qualified_symbol": "django.middleware.csrf.py.rotate_token",
+          "symbol_kind": "function",
+          "start_line": 117,
+          "end_line": 117
+        }
+      ]
+    },
+    {
+      "id": "SR12",
+      "query": "Negative query: symbol that should not exist",
+      "rg_pattern": "this_symbol_should_not_exist_abcdef1234",
+      "targets": []
+    },
+    {
+      "id": "SR13",
+      "query": "Where is Http404 implemented?",
+      "rg_pattern": "^class\\s+Http404\\b",
+      "targets": [
+        {
+          "file": "django/http/response.py",
+          "qualified_symbol": "django.http.response.py.Http404",
+          "symbol_kind": "class",
+          "start_line": 699,
+          "end_line": 699
+        }
+      ]
+    },
+    {
+      "id": "SR14",
+      "query": "Where is HttpResponse implemented?",
+      "rg_pattern": "^class\\s+HttpResponse\\b",
+      "targets": [
+        {
+          "file": "django/http/response.py",
+          "qualified_symbol": "django.http.response.py.HttpResponse",
+          "symbol_kind": "class",
+          "start_line": 364,
+          "end_line": 364
+        }
+      ]
+    },
+    {
+      "id": "SR15",
+      "query": "Where is JsonResponse implemented?",
+      "rg_pattern": "^class\\s+JsonResponse\\b",
+      "targets": [
+        {
+          "file": "django/http/response.py",
+          "qualified_symbol": "django.http.response.py.JsonResponse",
+          "symbol_kind": "class",
+          "start_line": 703,
+          "end_line": 703
+        }
+      ]
+    },
+    {
+      "id": "SR16",
+      "query": "Where is QuerySet implemented?",
+      "rg_pattern": "^class\\s+QuerySet\\b",
+      "targets": [
+        {
+          "file": "django/db/models/query.py",
+          "qualified_symbol": "django.db.models.query.py.QuerySet",
+          "symbol_kind": "class",
+          "start_line": 293,
+          "end_line": 293
+        }
+      ]
+    },
+    {
+      "id": "SR17",
+      "query": "Where is Q implemented?",
+      "rg_pattern": "^class\\s+Q\\b",
+      "targets": [
+        {
+          "file": "django/db/models/query_utils.py",
+          "qualified_symbol": "django.db.models.query_utils.py.Q",
+          "symbol_kind": "class",
+          "start_line": 38,
+          "end_line": 38
+        }
+      ]
+    },
+    {
+      "id": "SR18",
+      "query": "Where is Model implemented?",
+      "rg_pattern": "^class\\s+Model\\b",
+      "targets": [
+        {
+          "file": "django/db/models/base.py",
+          "qualified_symbol": "django.db.models.base.py.Model",
+          "symbol_kind": "class",
+          "start_line": 459,
+          "end_line": 459
+        }
+      ]
+    },
+    {
+      "id": "SR19",
+      "query": "Where is atomic implemented?",
+      "rg_pattern": "^def\\s+atomic\\b",
+      "targets": [
+        {
+          "file": "django/db/transaction.py",
+          "qualified_symbol": "django.db.transaction.py.atomic",
+          "symbol_kind": "function",
+          "start_line": 316,
+          "end_line": 316
+        }
+      ]
+    },
+    {
+      "id": "SR20",
+      "query": "Where is MiddlewareMixin implemented?",
+      "rg_pattern": "^class\\s+MiddlewareMixin\\b",
+      "targets": [
+        {
+          "file": "django/utils/deprecation.py",
+          "qualified_symbol": "django.utils.deprecation.py.MiddlewareMixin",
+          "symbol_kind": "class",
+          "start_line": 95,
+          "end_line": 95
+        }
+      ]
+    },
+    {
+      "id": "SR21",
+      "query": "Where is cached_property implemented?",
+      "rg_pattern": "^class\\s+cached_property\\b",
+      "targets": [
+        {
+          "file": "django/utils/functional.py",
+          "qualified_symbol": "django.utils.functional.py.cached_property",
+          "symbol_kind": "class",
+          "start_line": 7,
+          "end_line": 7
+        }
+      ]
+    },
+    {
+      "id": "SR22",
+      "query": "Where is LazyObject implemented?",
+      "rg_pattern": "^class\\s+LazyObject\\b",
+      "targets": [
+        {
+          "file": "django/utils/functional.py",
+          "qualified_symbol": "django.utils.functional.py.LazyObject",
+          "symbol_kind": "class",
+          "start_line": 259,
+          "end_line": 259
+        }
+      ]
+    },
+    {
+      "id": "SR23",
+      "query": "Where is AppConfig implemented?",
+      "rg_pattern": "^class\\s+AppConfig\\b",
+      "targets": [
+        {
+          "file": "django/apps/config.py",
+          "qualified_symbol": "django.apps.config.py.AppConfig",
+          "symbol_kind": "class",
+          "start_line": 13,
+          "end_line": 13
+        }
+      ]
+    },
+    {
+      "id": "SR24",
+      "query": "Where is Apps implemented?",
+      "rg_pattern": "^class\\s+Apps\\b",
+      "targets": [
+        {
+          "file": "django/apps/registry.py",
+          "qualified_symbol": "django.apps.registry.py.Apps",
+          "symbol_kind": "class",
+          "start_line": 13,
+          "end_line": 13
+        }
+      ]
+    },
+    {
+      "id": "SR25",
+      "query": "Where is BaseCommand implemented?",
+      "rg_pattern": "^class\\s+BaseCommand\\b",
+      "targets": [
+        {
+          "file": "django/core/management/base.py",
+          "qualified_symbol": "django.core.management.base.py.BaseCommand",
+          "symbol_kind": "class",
+          "start_line": 184,
+          "end_line": 184
+        }
+      ]
+    },
+    {
+      "id": "SR26",
+      "query": "Where is execute_from_command_line implemented?",
+      "rg_pattern": "^def\\s+execute_from_command_line\\b",
+      "targets": [
+        {
+          "file": "django/core/management/__init__.py",
+          "qualified_symbol": "django.core.management.__init__.py.execute_from_command_line",
+          "symbol_kind": "function",
+          "start_line": 439,
+          "end_line": 439
+        }
+      ]
+    },
+    {
+      "id": "SR27",
+      "query": "Where is render implemented?",
+      "rg_pattern": "^def\\s+render\\b",
+      "targets": [
+        {
+          "file": "django/shortcuts.py",
+          "qualified_symbol": "django.shortcuts.py.render",
+          "symbol_kind": "function",
+          "start_line": 18,
+          "end_line": 18
+        }
+      ]
+    },
+    {
+      "id": "SR28",
+      "query": "Where is redirect implemented?",
+      "rg_pattern": "^def\\s+redirect\\b",
+      "targets": [
+        {
+          "file": "django/shortcuts.py",
+          "qualified_symbol": "django.shortcuts.py.redirect",
+          "symbol_kind": "function",
+          "start_line": 29,
+          "end_line": 29
+        }
+      ]
+    },
+    {
+      "id": "SR29",
+      "query": "Where is reverse implemented?",
+      "rg_pattern": "^def\\s+reverse\\b",
+      "targets": [
+        {
+          "file": "django/urls/base.py",
+          "qualified_symbol": "django.urls.base.py.reverse",
+          "symbol_kind": "function",
+          "start_line": 27,
+          "end_line": 27
+        }
+      ]
+    },
+    {
+      "id": "SR30",
+      "query": "Where is include implemented?",
+      "rg_pattern": "^def\\s+include\\b",
+      "targets": [
+        {
+          "file": "django/urls/conf.py",
+          "qualified_symbol": "django.urls.conf.py.include",
+          "symbol_kind": "function",
+          "start_line": 17,
+          "end_line": 17
+        }
+      ]
+    },
+    {
+      "id": "SR31",
+      "query": "Where is csrf_exempt implemented?",
+      "rg_pattern": "^def\\s+csrf_exempt\\b",
+      "targets": [
+        {
+          "file": "django/views/decorators/csrf.py",
+          "qualified_symbol": "django.views.decorators.csrf.py.csrf_exempt",
+          "symbol_kind": "function",
+          "start_line": 51,
+          "end_line": 51
+        }
+      ]
+    },
+    {
+      "id": "SR32",
+      "query": "Where is login_required implemented?",
+      "rg_pattern": "^def\\s+login_required\\b",
+      "targets": [
+        {
+          "file": "django/contrib/auth/decorators.py",
+          "qualified_symbol": "django.contrib.auth.decorators.py.login_required",
+          "symbol_kind": "function",
+          "start_line": 72,
+          "end_line": 72
+        }
+      ]
+    }
+  ]
+}

--- a/docs/TLDR.md
+++ b/docs/TLDR.md
@@ -59,7 +59,7 @@ Finds functions by behavior because **every function is embedded with:**
 - **L5:** Dependencies (imports, external modules)
 - **Plus:** First ~10 lines of code
 
-This gets encoded into **1024-dimensional embeddings** via `bge-large-en-v1.5`, so semantic search finds `verify_access_token()` even when you ask about JWT validation.
+By default this gets encoded into **1024-dimensional embeddings** via `bge-large-en-v1.5`, so semantic search finds `verify_access_token()` even when you ask about JWT validation. `jina-code-0.5b` is also available as an opt-in model for code-focused retrieval, but it requires a full semantic reindex because it produces 896-dimensional embeddings.
 
 #### Why Both Forward AND Backward Call Graphs?
 
@@ -436,8 +436,10 @@ Traditional search finds syntax. TLDR semantic search finds behavior.
        ...
    ```
 
-3. **Encode with bge-large-en-v1.5** → 1024-dimensional vector
+3. **Encode with the selected embedding model** → 1024-dimensional vector by default (`bge-large-en-v1.5`), 896-dimensional when opting into `jina-code-0.5b`
 4. **FAISS index** for fast similarity search
+
+> `jina-code-0.5b` is opt-in, requires rebuilding semantic artifacts for the target index, and carries a non-commercial license caveat unless separately licensed.
 
 ### Example Queries
 

--- a/docs/llm-tldr-reference-card.md
+++ b/docs/llm-tldr-reference-card.md
@@ -1,79 +1,114 @@
-# llm-tldr Reference Card
+# llm-tldr One-Page Usage Guide
 
-> Code analysis CLI with semantic retrieval, structural analysis, and daemon mode.
-> Invoke via `tldrf` (CLI), daemon socket (JSON), or MCP server (editor integrations).
+> Use `rg-native` for exact lookup. Use `tldrf` when you need structure, blast radius, slices, or concept search. Use daemon or MCP for repeated queries.
+> If you are running from this repo checkout instead of an installed CLI, prefix commands with `uv run`.
 
-## Capabilities
+## Start Here
 
-| Capability | What it does | When to reach for it | CLI | Daemon JSON | Daemon p50 | Tokens |
-|---|---|---|---|---|---:|---:|
-| **Semantic search** | Hybrid lexical+semantic code retrieval for NL queries | Don't know exact names; exploring | `tldrf semantic search "{q}" --path .` | `{"cmd":"semantic","action":"search","query":"{q}","k":10}` | 290 ms | 78 |
-| **Impact analysis** | All callers of a function (who calls this?) | Blast radius before refactoring | `tldrf impact "{fn}" . --file {f}` | `{"cmd":"impact","func":"{fn}","file":"{f}"}` | 14 ms | 26 |
-| **Context / call graph** | Reachable functions from entry point at depth N | What does a change propagate to? | `tldrf context "{entry}" --project . --depth {n}` | `{"cmd":"context","entry":"{entry}","depth":{n}}` | 0.2 ms* | 128 |
-| **Slice** | Backward trace: lines influencing a variable at a point | Where does a bad value originate? | `tldrf slice "{file}" "{fn}" {line}` | `{"cmd":"slice","file":"{f}","function":"{fn}","line":{n}}` | 5 ms | 11 |
-| **Data flow (DFG)** | Forward trace: how data moves through a function | Data transformations after slicing | `tldrf dfg "{file}" "{fn}"` | `{"cmd":"dfg","file":"{f}","function":"{fn}"}` | 3 ms | 13 |
-| **CFG / complexity** | Cyclomatic complexity of a function | Complex hotspots; test prioritization | `tldrf cfg "{file}" "{fn}"` | `{"cmd":"cfg","file":"{f}","function":"{fn}"}` | 1.7 ms | 8 |
+| If the question is... | Reach for | Why / measured evidence |
+|---|---|---|
+| Exact string, symbol, import, file path, or definition | `rg-native` first | Exact-definition retrieval is `F1 0.9841` for `rg-native` vs `0.1602` for BGE and `0.1520` for Jina. |
+| "What breaks if I change this?" | `tldrf impact` -> `tldrf context` -> `rg-native` | Deterministic caller graphs beat grep-style baselines on impact, then `rg` closes lexical cleanup gaps. |
+| "Why is this value wrong here?" | `tldrf slice` -> `tldrf dfg`; add `tldrf cfg` for branch bugs | Slice is the strongest debugging workflow: `F1 0.919`; DFG origin / flow accuracy is `1.0`. |
+| "I do not know the symbol name, only the behavior" | `tldrf semantic search` with the default hybrid path | llm-tldr retrieval at `budget=2000` beats `rg-native` on ranking quality (`MRR 0.874` vs `0.813`) while adding structural follow-up tools. |
+| Repeated agent or editor queries | Daemon or MCP, not direct CLI subprocesses | Daemon mode cuts warm retrieval from about `5s` to about `293ms` and structural commands by `15x-93x`. |
+| Pure semantic concept lookup or semantic-only tight-budget retrieval | `jina-code-0.5b` opt-in | Jina improves semantic-only retrieval (`MRR 0.7023` vs `0.6022`) and budget-`1000` semantic retrieval (`0.7048` vs `0.6124`). |
 
-*Context: 0.2 ms warm (cached call graph); ~15.5 s cold start on first call per entry point.
-Dispatch rule: `entry` with `/` and no `.` uses module-path mode; all other entries use symbol mode.
+## Default Workflows
 
-## Proven Workflows
+| Workflow | Default path | When it is the right tool |
+|---|---|---|
+| Refactor safely | `impact` -> `context` -> `rg-native` | Use this before renaming, splitting, deleting, or changing a signature. |
+| Debug precisely | `slice` -> `dfg` -> `cfg` | Use this when you know the failing line or function and want the smallest relevant context. |
+| Onboard to unfamiliar code | `semantic search` -> `context` -> `impact` | Use this when you know intent but not names, then tighten to symbol-level reasoning. |
+| Exact cleanup / migration sweep | `rg-native` -> direct reads | Use this for exhaustive imports, docs, configs, generated files, and module-level code. |
+| Multi-query agent session | MCP or daemon-backed calls | Use this whenever an LLM or script will issue more than one query against the same repo. |
 
-| Workflow | Steps | Use when | Expected signal |
-|---|---|---|---|
-| **Refactor path** | `impact` -> `context` -> `rg` | Changing a function; need blast radius + affected code + lexical confirmation | impact f1=0.848, context f1=0.880, then rg for final grep validation |
-| **Debug path** | `slice` -> `dfg` | Tracing a bad value back to its source, then forward through transformations | slice f1=0.919, dfg origin/flow accuracy=1.0 |
-| **Discovery path** | `semantic search` (lane 2 or 3) | Onboarding to codebase; finding implementations by concept | MRR=0.874, recall@5=0.877, zero false positives |
+## Commands To Memorize
 
-## Retrieval Lanes
+| Task | Command |
+|---|---|
+| Exact lookup | `rg -n "pattern" .` |
+| Blast radius | `tldrf impact "function_name" . --file path/to/file.py` |
+| Reachable context | `tldrf context "function_name" --project . --depth 2` |
+| Minimal debug slice | `tldrf slice path/to/file.py function_name 42` |
+| Data provenance | `tldrf dfg path/to/file.py function_name` |
+| Control-flow hotspot | `tldrf cfg path/to/file.py function_name` |
+| Concept search | `tldrf semantic search "natural language intent" --path . --k 8 --hybrid` |
+| Affected tests | `tldrf change-impact` |
+| Start daemon | `tldrf daemon start --project .` |
+| Keep the index fresh | `tldrf daemon notify path/to/file.py --project .` |
 
-Lanes stack incrementally. **Lane 1 (hybrid) is the recommended default** — highest recall. Use lane 3 when token budget is tight.
+## Session Setup That Actually Pays Off
 
-| Lane | Strategy | Adds over previous | MRR | R@5 | Best for |
-|---|---|---|---:|---:|---|
-| 1 | Hybrid | Lexical + semantic fusion | 0.856 | **0.930** | **Default** — finds the most relevant results |
-| 2 | Abstain/rerank | Confidence filtering + reranking | 0.874 | 0.877 | Higher ranking precision; filtering low-confidence noise |
-| 3 | Budget-aware | Dynamic k based on token budget | 0.874 | 0.877 | Token-constrained contexts (best MRR + budget respect) |
-| 4 | Compound | Semantic + impact jointly | 0.745 | 0.818 | Finding code that is both relevant AND called often |
-| 5 | Navigate-cluster | Semantic clustering of results | 0.874 | 0.877 | Exploring multiple facets of a broad query |
+Use the same cache root and index id across the whole session. That is what turns tldrf from a slow CLI command into a reusable code index.
 
-Lane 5 determinism: 1.0 coverage, 1.0 digest match, 0.982 cluster recall@3 (n=180).
+```bash
+ROOT="$(git rev-parse --show-toplevel)"
+INDEX_ID="repo:<project>"
 
-## Performance (Daemon vs Subprocess)
+tldrf warm --cache-root "$ROOT" --index "$INDEX_ID" --lang python .
+tldrf semantic index --cache-root "$ROOT" --index "$INDEX_ID" --lang python .
+tldrf daemon start --cache-root "$ROOT" --index "$INDEX_ID" --scan-root .
+```
 
-Always use daemon for multi-query sessions. MCP server auto-starts it.
+- Build once, then query the warm daemon or MCP repeatedly instead of respawning the CLI.
+- Reuse the same `--cache-root` and `--index` across agent turns, scripts, and editor sessions.
+- Pin `--lang` on structural commands in mixed-language repos.
+- Prefer explicit `--cache-root "$ROOT"` over `--cache-root git` until that shortcut has stable regression coverage.
+- After edits, use `tldrf daemon notify <changed-file> --project .` or rerun `warm` when the project has drifted a lot.
 
-| Category | Subprocess p50 | Daemon p50 | Speedup |
-|---|---:|---:|---:|
-| Retrieval (lanes 1-5) | ~5000 ms | ~293 ms | 17x |
-| Impact | 212 ms | 14 ms | 15x |
-| Context (warm) | 15,516 ms | 0.2 ms | 82,000x |
-| Slice | 169 ms | 5 ms | 32x |
-| Data flow | 158 ms | 3 ms | 55x |
-| Complexity | 157 ms | 1.7 ms | 93x |
+## Current Gotchas To Remember
 
-Daemon retrieval is within **1.37x of rg-native** p50 (216 ms). All results byte-identical to subprocess.
+- Plain CLI commands are still fresh-process invocations. `docs/usage.md` is the accurate source for daemon vs subprocess behavior.
+- `warm` does not replace `semantic index`; structural and semantic setup are separate steps.
+- Exact identifier and definition lookup is still a grep problem. Do not treat semantic retrieval as a replacement for `rg-native` there.
 
-## Comparison (Retrieval @ 2000 token budget)
+## Recommended Defaults
 
-| Tool | MRR | Recall@5 | FPR@5 | p50 | Payload tokens | Structural workflows |
-|---|---:|---:|---:|---:|---:|---|
-| **llm-tldr** (lane 2/3) | **0.874** | **0.877** | **0.0** | 293 ms (daemon) | 78 | impact, context, slice, dfg, cfg |
-| rg-native | 0.813 | 0.877 | 0.0 | 216 ms | 12 | none |
-| contextplus | 0.216 | 0.298 | 1.0 | 7,717 ms | 329 | none |
+| Decision | Current default | Why |
+|---|---|---|
+| Exact lookup tool | `rg-native` | Lexical lookup is still the right first tool for symbol / definition search. |
+| Product retrieval model | `bge-large-en-v1.5` | Jina is roughly tied on common `hybrid_rrf`, but BGE still wins lane2 MRR, compound efficiency, and structured concept retrieval. |
+| Semantic-only experiment model | `jina-code-0.5b` opt-in | Jina is the better pure semantic model on the current Django evidence, but it requires a semantic rebuild and separate license review. |
+| Query execution mode | Daemon or MCP | Warm daemon mode is fast enough to be practical and avoids repeated model loads. |
 
-**Bottom line:** llm-tldr matches rg recall with +7% MRR at 1.37x latency, plus six structural capabilities alternatives lack. contextplus is 4x slower with 100% false positive rate.
+Current product decision: keep `BGE` as the default model, keep `Jina` opt-in, and keep `rg-native` as the first tool for exact lookup.
 
-## Execution Modes
+## What The Benchmarks Actually Support
 
-| Context | Path | Model load | Latency |
-|---|---|---|---:|
-| `tldrf <cmd>` | CLI direct | Every call | ~5000 ms |
-| `tldrf daemon query --json '{...}'` | Daemon socket | Once | ~300 ms |
-| `tldrf mcp` | MCP -> daemon | Once | ~300 ms |
+| Claim | Current signal |
+|---|---|
+| llm-tldr is better than `contextplus` on retrieval | Yes. Shared retrieval lanes are decisive in the 008 comparison program. |
+| llm-tldr gives better final answers than `rg-native` on structured debugging / analysis tasks | Yes. Open-ended judge win rate over `rg` is `0.694` at `budget=2000`. |
+| llm-tldr is worth using for refactors and debugging | Yes. Impact, slice, DFG, CFG, and token-efficiency benchmarks all show lower-noise structural context than grep-style baselines. |
+| llm-tldr should replace `rg-native` for exact identifier lookup | No. Exact lexical lookup is still a grep problem. |
+| Jina should replace BGE as the default model | No. Jina wins semantic-only retrieval, but not the broader product path. |
 
-**Rule of thumb:** More than one query? Use the daemon. MCP does this automatically.
+## Where tldrf Adds Value Over rg-native
 
-Start: `tldrf daemon start --project .` | Stop: `tldrf daemon stop --project .`
+- `impact`: deterministic reverse call graph for blast radius instead of grep guesses.
+- `slice` and `dfg`: line-level provenance and forward flow, which `rg` cannot infer.
+- `context`: call-graph-bounded summaries that reduce context rot and token waste.
+- `semantic search`: concept lookup when the user knows behavior but not names.
+- daemon or MCP reuse: index once, keep it warm, avoid repeated lossy full-repo search.
 
-> Deep dive: `docs/usage.md` (execution modes), `implementations/008-benchmark-summary.md` (full runbook)
+## Gaps To Close Next
+
+- Add end-to-end edit-loop benchmarks with time-to-first-correct-edit, token spend, and changed-file recall against `rg-native`.
+- Add edit-loop benchmarks for `daemon notify` and auto-reindex latency so "index once, keep it fresh" is measured, not assumed.
+- Add task-level refactor benchmarks with gold changed-file / changed-symbol sets to prove fewer misses than `rg-native` during code modification, not just retrieval quality.
+- Rerun downstream judge-mode comparisons on workflows that explicitly use `impact` + `context` and `slice` + `dfg`, not only retrieval packets.
+- Complete dependency-scoped BGE vs Jina benchmarks (`requests`, `urllib3`) so model guidance is not Django-only.
+- Add mixed-language and monorepo structural-quality benchmarks to prove the workflow scales beyond the current Python-heavy evidence.
+- Add stronger hybrid negative-query guard benchmarks; current strict `rg_empty` behavior on the structured behavior suite is too aggressive to treat as production guidance.
+- Add more user-facing daemon parity coverage so repeated CLI workflows can route through the daemon without raw JSON callsites.
+- Clean up longer-form docs that still imply `warm` alone builds semantic embeddings automatically; the one-pager is the correct guidance for now.
+- Add doc-and-help parity coverage for `semantic search` syntax, `warm` vs `semantic index`, `--cache-root` handling, and explicit `--lang` requirements during indexing.
+
+## Docs Map
+
+- This page: task selection and defaults.
+- `benchmarks/README.md`: aggregate benchmark results and model/tool comparison matrix.
+- `docs/usage.md`: execution modes, daemon vs subprocess behavior.
+- `implementations/008-benchmark-summary.md`: operator handoff and canonical benchmark runbook.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -152,6 +152,43 @@ Result correctness: all predictions byte-identical between subprocess and daemon
 - **Result parity**: All retrieval predictions across lanes 1-5 are byte-identical between subprocess and daemon modes
 - **Structural parity**: impact 15/15 semantic match (caller ordering differs), slice/complexity/data_flow exact match
 
+## Lane 1 vs Lane 2
+
+The short version: `lane1` is the normal retrieval path. `lane2` is the stricter
+retrieval policy.
+
+- `lane1` means "run the hybrid retrieval and return the ranked results."
+- `lane2` means "take that retrieval output and add confidence shaping, optional
+  reranking, and optional abstention when confidence is too low."
+
+Why `lane2` exists:
+- It is useful when a weak top hit is worse than returning nothing.
+- It gives benchmark and production-style profiles a way to be more conservative
+  about ambiguous queries.
+- It is the right surface if you want to test bounded retrieval policies such as
+  abstain-threshold and rerank behavior.
+
+Why `lane1` is still the practical default:
+- For normal interactive use, the main value is already there: hybrid retrieval
+  finds the candidate code, then `impact`, `context`, `slice`, `dfg`, or `cfg`
+  provide the deterministic follow-up.
+- The measured deltas between `lane1` and `lane2` were real but small, not a
+  dramatic product shift.
+- In practice, `lane2` is better treated as a stricter benchmark or gating
+  surface than as the everyday default path.
+
+On the Django daemon benchmarks, that trade-off was visible directly:
+- BGE `lane1` common hybrid row: `MRR 0.8684`, `R@5 0.9649`, `P@5 0.1930`
+- BGE `lane2` common hybrid row: `MRR 0.8741`, `R@5 0.8772`, `P@5 0.1754`
+- Jina `lane1` common hybrid row: `MRR 0.8686`, `R@5 0.9825`, `P@5 0.1965`
+- Jina `lane2` common hybrid row: `MRR 0.8417`, `R@5 0.9123`, `P@5 0.1825`
+
+That is why the operator guidance is:
+- Use `lane1` for normal retrieval.
+- Use `lane2` only when you explicitly want abstention/rerank behavior.
+- Do not treat a small `lane2` benchmark win as more important than the broader
+  workflow, which is usually `lane1 -> impact/context/slice/dfg/cfg`.
+
 ## Summary: Which Path Am I On?
 
 | Context | Execution Path | Model Load | Latency |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,5 +1,8 @@
 # Execution Modes: When the Daemon Is Used
 
+Task-based usage guidance lives in [`docs/llm-tldr-reference-card.md`](./llm-tldr-reference-card.md).
+This page is narrower: it explains CLI direct vs daemon vs MCP execution, latency behavior, and daemon-specific gaps.
+
 llm-tldr has three execution paths for queries. Understanding which one is active
 determines whether you pay model-load overhead on every query or amortize it once.
 

--- a/implementations/008-beat-contextplus_IMPLEMENTATION_PLAN.md
+++ b/implementations/008-beat-contextplus_IMPLEMENTATION_PLAN.md
@@ -342,6 +342,33 @@ Rows below are the required workflow board for overall product winner decisions:
 | `cfg` / complexity | `accuracy=0.600, mae=1.800, p50=151.115ms, tok=8` | unsupported (`N/A`) | unsupported (`N/A`) | complexity metrics in `benchmark/runs/h2h-llm-tldr-score-run1-fixed-stitched-allowlist-20260302T062602Z.json` |
 | Daemon/index operational metrics | `build_s=1.231, patch_s=0.815, rebuild_s=1.070`; `daemon-vs-cli p50 pending` | unsupported (`N/A`) | unsupported (`N/A`) | provisional TS perf metrics: `benchmark/runs/20260209-044240Z-ts-perf-ts-monorepo.json`; next artifact via `scripts/bench_perf_daemon_vs_cli.py` |
 
+### 009 Model-Variant Addendum (BGE Default vs Jina Opt-In)
+
+Use this addendum when the question is not just "how does llm-tldr compare to contextplus or rg-native?" but "where, if anywhere, is `jina-code-0.5b` actually better than the current BGE-backed default?"
+
+Protocol note:
+- These rows come from the daemon-mode Django migration evaluation in `implementations/009-migrate-bge-to-jina-code-0.5b_IMPLEMENTATION_PLAN.md`.
+- They complement the canonical 008 h2h matrix; they do not replace it. Several rows are deterministic retrieval or structured-scoring probes rather than full h2h segment exports.
+
+| Evaluation surface | BGE | Jina | Delta / winner | Comparator context | Evidence / decision note |
+| --- | --- | --- | --- | --- | --- |
+| Common lane `hybrid_rrf` retrieval quality | `mrr=0.8684`, `r@5=0.9649`, `r@10=1.0000`, `p@5=0.1930`, `fpr@5=1.0000` | `mrr=0.8686`, `r@5=0.9825`, `r@10=1.0000`, `p@5=0.1965`, `fpr@5=1.0000` | Jina slight quality edge, effectively a tie | Both remain well above `contextplus` retrieval quality in this program; `rg-native` still wins latency | `benchmark/runs/20260306-101803Z-retrieval-django-bge-daemon.json`; `benchmark/runs/20260306-103455Z-retrieval-django-jina05b-daemon.json` |
+| Common lane `hybrid_lane2` retrieval quality | `mrr=0.8741`, `r@5=0.8772`, `r@10=0.9649`, `p@5=0.1754`, `fpr@5=1.0000` | `mrr=0.8417`, `r@5=0.9123`, `r@10=1.0000`, `p@5=0.1825`, `fpr@5=1.0000` | BGE wins the gate row on MRR; Jina gains recall/precision but loses ranking quality | This is the closest model-variant analogue to the existing 008 "Retrieval (common lane)" board row | `benchmark/runs/20260306-101803Z-retrieval-django-bge-lane2-daemon.json`; `benchmark/runs/20260306-103542Z-retrieval-django-jina05b-lane2-daemon.json` |
+| Pure semantic concept-path retrieval | `mrr=0.6022`, `r@5=0.7719`, `r@10=0.7895`, `p@5=0.1544`, `fpr@5=1.0000` | `mrr=0.7023`, `r@5=0.8596`, `r@10=0.8772`, `p@5=0.1719`, `fpr@5=1.0000` | Jina clearly wins pure semantic retrieval | Both semantic models are materially stronger than the current `contextplus` concept-path row; `rg-native` is not the right comparator for this lane | `benchmark/runs/20260306-101803Z-retrieval-django-bge-daemon.json`; `benchmark/runs/20260306-103455Z-retrieval-django-jina05b-daemon.json` |
+| Token-efficiency retrieval @ `1000` | `semantic=0.6124`, `hybrid_rrf=0.8597` | `semantic=0.7048`, `hybrid_rrf=0.8647` | Jina wins semantic strongly; hybrid only slightly | Useful when the question is retrieval quality under budget pressure rather than common-lane ranking alone | `benchmark/runs/20260306-101949Z-token-efficiency-django-bge-daemon.json`; `benchmark/runs/20260306-103645Z-token-efficiency-django-jina05b-daemon.json` |
+| Compound semantic+impact | `tte_p50_ratio=1.0250`, `retrieval_overlap=1.0`, `impact_callers_jaccard=1.0` | `tte_p50_ratio=1.1361`, `retrieval_overlap=1.0`, `impact_callers_jaccard=1.0` | BGE wins efficiency; correctness is tied | `contextplus` / `rg-native` do not cover this lane, so this is an intra-tool product-path decision | `benchmark/runs/20260306-102247Z-compound-semantic-impact-django-bge-daemon.json`; `benchmark/runs/20260306-103725Z-compound-semantic-impact-django-jina05b-daemon.json` |
+| Structured exact-definition retrieval | `f1=0.1602`, `p50=142.1ms` | `f1=0.1520`, `p50=140.3ms` | BGE slight quality win; Jina only marginally faster | `rg-native=0.9841` dominates this exact lookup task, so neither semantic model should replace lexical search here | `benchmark/runs/20260306-182147Z-structured-retrieval-django.json` |
+| Structured behavior retrieval (semantic) | `f1=0.1458`, `p50=169.5ms` | `f1=0.1053`, `p50=185.9ms` | BGE wins | `rg-native=0.0217` on the same suite, so semantic retrieval is adding real value for concept-style target recovery | `benchmark/runs/20260306-185707Z-structured-retrieval-django.json` |
+| Structured behavior retrieval (hybrid) | `f1=0.1584`, `p50=422.9ms` | `f1=0.1188`, `p50=438.5ms` | BGE wins | Both hybrid variants beat `rg-native=0.0217`, but this harness includes deterministic file-to-symbol projection | `benchmark/runs/20260306-185707Z-structured-retrieval-django.json` |
+| Structured behavior retrieval (hybrid + `rg_empty`) | `f1=0.0000`, `p50=358.0ms` | `f1=0.0000`, `p50=358.3ms` | Tie; both unusable on this suite | The guard fixed the negative query but suppressed all positive hybrid queries because the lexical guard patterns were too weak | `benchmark/runs/20260306-190233Z-structured-retrieval-django.json` |
+| Steady-state daemon semantic latency | `p50=150.2ms`, `p95=250.2ms` | `p50=166.5ms`, `p95=286.4ms` | BGE faster by roughly `10-14%` | This is steady-state query latency, not the one-time build/rebuild cost | `benchmark/runs/20260306-adhoc-daemon-semantic-latency-bge-vs-jina.json` |
+| Semantic build / memory cost | comparable fresh rebuild still pending | `build_s=692.57`, `peak_rss=3360.1MB` | Jina operationally heavier | This is one of the reasons the current migration decision stays `KEEP_OPT_IN` | `benchmark/logs/20260306-101553Z-django-jina05b-semantic.log`; BGE rebuild parity still pending |
+
+Model-variant bottom line:
+- Jina is useful when the objective is pure semantic concept retrieval or budget-limited semantic retrieval.
+- BGE remains the stronger default for the full product because lane2, compound efficiency, structured exact/behavior retrieval, and operational cost still favor BGE.
+- `rg-native` remains the right first tool for exact identifier and definition lookup regardless of embedding model.
+
 ### Canonical Run1 Row IDs (Exported)
 
 Primary required rows (`budget_tokens=2000`):

--- a/implementations/008-benchmark-summary.md
+++ b/implementations/008-benchmark-summary.md
@@ -55,6 +55,27 @@ Summary values:
 ### Stability caveat (important)
 Single-run segment asserts can pass strict run-level gates while still failing overall due `stability.two_of_three` if only one run was executed.
 
+## 009 Model-Variant Snapshot (BGE Default vs Jina Opt-In)
+
+This addendum keeps the same-tool model decision in the 008 operator handoff rather than leaving it only in the migration plan. Source of truth for the run log and report inventory: `implementations/009-migrate-bge-to-jina-code-0.5b_IMPLEMENTATION_PLAN.md`.
+
+| Scenario | BGE | Jina | Comparator context | Operational takeaway |
+| --- | --- | --- | --- | --- |
+| Common lane `hybrid_rrf` retrieval | `mrr=0.8684`, `r@5=0.9649`, `r@10=1.0000`, `p@5=0.1930` | `mrr=0.8686`, `r@5=0.9825`, `r@10=1.0000`, `p@5=0.1965` | 008 snapshot: `rg=0.820`, `contextplus=0.216` MRR | Near tie. Jina has only a marginal lane1 edge. |
+| Common lane `hybrid_lane2` retrieval | `mrr=0.8741`, `r@5=0.8772`, `r@10=0.9649`, `p@5=0.1754` | `mrr=0.8417`, `r@5=0.9123`, `r@10=1.0000`, `p@5=0.1825` | Gate-like lane row | Keep BGE default. Jina loses the MRR-heavy gate row. |
+| Pure semantic concept retrieval | `mrr=0.6022`, `r@5=0.7719`, `r@10=0.7895`, `p@5=0.1544` | `mrr=0.7023`, `r@5=0.8596`, `r@10=0.8772`, `p@5=0.1719` | Concept lookup only | Jina is the better semantic-only model on current evidence. |
+| Token-efficiency retrieval at `1000` | `semantic=0.6124`, `hybrid_rrf=0.8597` | `semantic=0.7048`, `hybrid_rrf=0.8647` | Budget-constrained retrieval | Jina helps semantic quality under tighter token budgets; hybrid stays nearly tied. |
+| Structured exact-definition retrieval | `f1=0.1602`, `p50=142.1ms` | `f1=0.1520`, `p50=140.3ms` | `rg-native=0.9841`, `p50=84.8ms` | Keep exact symbol lookup lexical. Neither embedding model should replace `rg-native` here. |
+| Structured behavior retrieval (semantic / hybrid) | `semantic f1=0.1458`, `hybrid f1=0.1584` | `semantic f1=0.1053`, `hybrid f1=0.1188` | `rg-native=0.0217` on the same suite | Semantic and hybrid help on concept-style targets, but BGE beats Jina in both modes. |
+| Compound semantic+impact | `tte_p50_ratio=1.0250`, overlap/Jaccard parity `=1.0` | `tte_p50_ratio=1.1361`, overlap/Jaccard parity `=1.0` | No direct `contextplus` or `rg-native` equivalent | Jina does not regress correctness here, but it is less efficient than BGE on the product path. |
+| Steady-state daemon semantic latency | `p50=150.2ms`, `p95=250.2ms` | `p50=166.5ms`, `p95=286.4ms` | Query latency only | BGE is still about `10-14%` faster. |
+| Semantic build / peak RSS | parity rebuild still pending | `build_s=692.57`, `peak_rss=3360.1MB` | One-time index build | Jina is operationally heavier. |
+
+Decision summary:
+- Keep `bge-large-en-v1.5` as the default model.
+- Keep `jina-code-0.5b` opt-in for pure semantic concept retrieval and budget-constrained semantic retrieval experiments.
+- Keep `rg-native` as the first tool for exact identifier and definition lookup.
+
 ## Reproducible Operator Runbook
 
 ### 1) Fetch pinned corpus

--- a/implementations/008-canonical-matrix-run1-snapshot.md
+++ b/implementations/008-canonical-matrix-run1-snapshot.md
@@ -50,6 +50,29 @@ This snapshot combines:
 | contextplus | 2000 | 0.21564327485380116 | 0.2982456140350877 | 0.3333333333333333 | 0.05964912280701755 | 1.0 | 329.0 | 7717.107 |
 | rg-native | 2000 | 0.8126218323586745 | 0.8771929824561403 | 0.9473684210526315 | 0.1754385964912281 | 0.0 | 12.0 | 216.22050000000002 |
 
+## 009 Model Variant Addendum (BGE vs Jina)
+
+These rows complement the canonical run1 snapshot with the daemon-mode Django migration results from `implementations/009-migrate-bge-to-jina-code-0.5b_IMPLEMENTATION_PLAN.md`. They are same-tool model comparisons, not replacements for the original 008 h2h rows.
+
+| Evaluation surface | BGE | Jina | Comparator context | What to take away |
+| --- | --- | --- | --- | --- |
+| Common lane `hybrid_rrf` quality | `mrr=0.8684`, `r@5=0.9649`, `r@10=1.0000`, `p@5=0.1930` | `mrr=0.8686`, `r@5=0.9825`, `r@10=1.0000`, `p@5=0.1965` | `contextplus` run1 remains far lower; `rg-native` remains much faster | Jina is roughly tied with BGE on lane1 quality, with only a marginal edge. |
+| Common lane `hybrid_lane2` quality | `mrr=0.8741`, `r@5=0.8772`, `r@10=0.9649`, `p@5=0.1754` | `mrr=0.8417`, `r@5=0.9123`, `r@10=1.0000`, `p@5=0.1825` | This is the closest model-variant analogue to the run1 retrieval board | BGE still wins the canonical gate row on MRR, so Jina does not displace the current default lane. |
+| Pure semantic concept-path quality | `mrr=0.6022`, `r@5=0.7719`, `r@10=0.7895`, `p@5=0.1544` | `mrr=0.7023`, `r@5=0.8596`, `r@10=0.8772`, `p@5=0.1719` | Both are stronger than the current `contextplus` concept-path row; `rg-native` is not the right comparator here | This is the main place Jina is genuinely better: pure semantic concept retrieval. |
+| Token-efficiency retrieval @ `1000` | `semantic=0.6124`, `hybrid_rrf=0.8597` | `semantic=0.7048`, `hybrid_rrf=0.8647` | Budgeted retrieval quality, not h2h run1 | Jina improves semantic quality under token pressure; hybrid gain is small. |
+| Compound semantic+impact | `tte_p50_ratio=1.0250`, correctness parity on overlap/Jaccard | `tte_p50_ratio=1.1361`, correctness parity on overlap/Jaccard | No direct `contextplus` / `rg-native` equivalent | Jina gives up efficiency on a product-path lane even though correctness is tied. |
+| Structured exact-definition retrieval | `f1=0.1602`, `p50=142.1ms` | `f1=0.1520`, `p50=140.3ms` | `rg-native=0.9841`, `p50=84.8ms` | Exact definition lookup remains a lexical problem; neither embedding model should replace `rg-native` here. |
+| Structured behavior retrieval (semantic) | `f1=0.1458`, `p50=169.5ms` | `f1=0.1053`, `p50=185.9ms` | `rg-native=0.0217`, `p50=87.3ms` | Semantic retrieval adds real value on concept-style target recovery, but BGE still beats Jina. |
+| Structured behavior retrieval (hybrid) | `f1=0.1584`, `p50=422.9ms` | `f1=0.1188`, `p50=438.5ms` | Same suite; both beat `rg-native` on quality | Hybrid helps concept-style recovery, but BGE still wins and this harness includes file-to-symbol projection overhead. |
+| Structured behavior retrieval (hybrid + `rg_empty`) | `f1=0.0000`, `p50=358.0ms` | `f1=0.0000`, `p50=358.3ms` | Negative query fixed; all positive hybrid queries suppressed | Strict lexical guards are too aggressive for the current behavior-query labels. |
+| Steady-state daemon semantic latency | `p50=150.2ms`, `p95=250.2ms` | `p50=166.5ms`, `p95=286.4ms` | Query latency only, not build cost | BGE is still faster at steady-state query time by about `10-14%`. |
+| Semantic build / memory cost | parity rebuild still pending | `build_s=692.57`, `peak_rss=3360.1MB` | Operational, not retrieval quality | Jina is operationally heavier, which is part of why the current decision remains `KEEP_OPT_IN`. |
+
+Bottom line:
+- Jina is useful over BGE when the task is pure semantic concept retrieval and semantic quality under budget is the priority.
+- BGE remains the better default model for the full product surface because lane2, compound efficiency, structured retrieval, and operational cost still favor it.
+- `rg-native` remains the correct first tool for exact symbol and definition lookup regardless of embedding model.
+
 ## Daemon-Mode Latency By Lane (Budget 2000, Retrieval, MPS GPU)
 
 All lanes rerun with `--use-daemon` on 2026-03-03. Results are byte-identical to subprocess mode. MPS GPU auto-detected.

--- a/implementations/009-migrate-bge-to-jina-code-0.5b_IMPLEMENTATION_PLAN.md
+++ b/implementations/009-migrate-bge-to-jina-code-0.5b_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,873 @@
+# BGE -> Jina Code Embeddings 0.5B Migration Implementation Plan
+
+- Status: In Progress
+- Owner: TBD
+- Last updated: 2026-03-06
+- Source: user-provided migration outline ("BGE-1.5 -> Jina Code Embeddings 0.5B Migration Plan"), plus local repo paths `tldr/semantic.py`, `tldr/cli.py`, `tldr/daemon/core.py`, and benchmark runners under `scripts/`
+
+## Next Steps (Recommended Order)
+
+1. Finish the active Jina Django semantic build and capture its `/usr/bin/time -l` output.
+2. Run the remaining daemon-mode Jina query benchmarks against `repo:django-jina05b` and compare them to the archived BGE daemon baseline.
+3. Run the CLI-only comparison exceptions that daemon mode cannot cover yet: fresh build-time/RSS and dependency-scoped semantic benchmarks.
+4. Fill Phase 6 and decide whether Jina stays opt-in, becomes default, or is rejected.
+
+## Decisions & Assumptions (locked for this plan)
+
+- This migration is **test-first**. Deterministic behavior changes ship only after `red -> green`; benchmark runs are acceptance evidence, not a substitute for invariant tests.
+- The migration target is **opt-in Jina support first**, not an immediate default-model swap.
+- `bge-large-en-v1.5` remains the default through the decision gate because:
+  - Existing indexes are 1024-dimensional and cannot be reused with an 896-dimensional model.
+- Local repo reality:
+  - `tldr/semantic.py` currently hardcodes the BGE query instruction `Represent this code search query: ...`.
+  - `build_semantic_index()` currently embeds `build_embedding_text(unit)` directly, so there is no document-side instruction/prefix.
+  - `get_model()` currently instantiates `SentenceTransformer(hf_name, device=device)` with no model-specific tokenizer kwargs.
+  - Most benchmark runners do **not** take an embedding-model flag; they consume whatever semantic index already exists for `--index`. Only `scripts/bench_dep_indexes.py` takes `--model` directly.
+- Benchmark comparability therefore uses **separate index ids per model**, not rebuild-in-place:
+  - Example: `repo:django-bge15`
+  - Example: `repo:django-jina05b`
+- Prefer the existing `sentence-transformers` load path first. If Jina cannot be made correct with explicit tokenizer/pooling configuration through that API, add a minimal dedicated adapter behind the same internal interface rather than changing the public CLI.
+- Dependency floor is already sufficient in the local repo:
+  - `sentence-transformers>=5.2.0`
+  - `transformers==4.57.3` in `uv.lock`
+  - `torch==2.9.1` in `uv.lock`
+
+## Non-goals (MVP)
+
+- Reworking lane2/lane4/lane5 retrieval semantics beyond what is required to keep model-specific query embeddings correct.
+- Making Jina the default before the benchmark and license gates pass.
+- Using Matryoshka truncation in the initial implementation. That is a fallback only if CPU latency regressions fail the gate.
+- Preserving binary compatibility with old semantic indexes. Rebuild is mandatory when switching dimensions.
+
+## High-level Architecture
+
+- Extend the semantic model registry in `tldr/semantic.py` from a lightweight `SUPPORTED_MODELS` mapping into a model profile contract that can answer:
+  - Hugging Face id
+  - embedding dimension
+  - query instruction/prefix
+  - document instruction/prefix
+  - tokenizer kwargs
+  - any model-specific loader requirements
+- Route embedding construction through explicit helpers:
+  - query-time helper for `semantic_search()`
+  - document-time helper for `build_semantic_index()`
+- Keep model metadata persisted in semantic index metadata and continue to reject model/dimension mismatches at read time.
+- Update CLI, daemon config defaults/help, and docs to expose Jina as a selectable model while keeping BGE as the default until rollout.
+
+## Program Delivery Mode: Test-First With Benchmark Confirmation
+
+This plan uses a hybrid method:
+
+1. Deterministic tests first for model metadata, instruction routing, loader kwargs, cache behavior, and mismatch guards.
+2. Benchmark runs second for retrieval quality, token efficiency, LLM answer quality, and performance.
+
+Phase rule: implementation work for a phase starts only after that phase's `Tests To Write First (Red)` list exists and fails for the intended behavior change.
+
+## Canonical Benchmark Matrix For This Migration
+
+The attached migration plan named the right benchmark families, but the local repo's scripts work slightly differently. This is the canonical local mapping:
+
+| Tier | Goal | Local runner | Notes |
+| --- | --- | --- | --- |
+| 1 | Direct semantic retrieval quality | `scripts/bench_retrieval_quality.py` | Local script emits `rg`, `semantic`, and `hybrid_rrf` in one report. `hybrid_lane2` appears only when lane2 flags are enabled. |
+| 1 | Dependency-scoped semantic quality | `scripts/bench_dep_indexes.py` | Already supports `--model` directly; use it for `requests` and `urllib3`. |
+| 2 | Retrieval quality under token budgets | `scripts/bench_token_efficiency.py --mode retrieval` | Use per-model `--index` ids; compare retrieval rows only. |
+| 2 | Compound semantic + impact | `scripts/bench_compound_semantic_impact.py` | Verifies retrieval-stage changes do not break lane4 effectiveness/latency. |
+| 2 | End-to-end LLM answer quality | `scripts/bench_llm_ab_prompts.py` + `scripts/bench_llm_ab_run.py` | Prompt generation is separate from answer-model execution in this repo. |
+| 3 | Index build time + peak RSS | manual `/usr/bin/time -l uv run tldrf semantic index ...` | Use separate index ids; record wall time and max RSS. |
+| 3 | Query latency p50/p95 | `scripts/bench_perf_daemon_vs_cli.py --include-semantic` | Point at a corpus/index that already has semantic artifacts. |
+| 4 | Optional head-to-head suite | `scripts/bench_head_to_head.py` | Nice to have only after earlier gates pass; requires model-specific tool/profile wiring or paired prediction artifacts. |
+
+## Benchmark Identity / Artifact Protocol
+
+- Use `benchmark/cache-root` as the shared cache root for all migration runs.
+- Use model-specific index ids everywhere a runner accepts `--index`:
+  - `repo:django-bge` for the current reusable BGE daemon/query baseline that already has valid semantic artifacts
+  - `repo:django-bge15` for a fresh BGE rebuild when build-time / peak-RSS parity is required
+  - `repo:django-jina05b` for the Jina candidate
+- Archive JSON outputs under `benchmark/runs/`.
+- For long runs, use `tmux` and tee logs under `benchmark/logs/` per `AGENTS.md`.
+
+Suggested log-friendly session naming:
+
+- `jina-bench-baseline`
+- `jina-bench-token`
+- `jina-bench-llm`
+
+## Phase 0: Lock The Migration Contract + Baseline Protocol
+
+**Goals**
+- Turn the model swap into an explicit contract instead of a hidden string replacement.
+- Capture the current BGE baseline using the local benchmark harness and artifact naming conventions.
+
+### Running Log (Phase 0)
+- 2026-03-06: Verified that `tldr/semantic.py` currently has one hardcoded BGE query prefix and no document-side prefixing.
+- 2026-03-06: Verified that `get_model()` currently has no model-specific `tokenizer_kwargs`, so Jina left-padding is not represented anywhere yet.
+- 2026-03-06: Verified that `scripts/bench_retrieval_quality.py`, `scripts/bench_token_efficiency.py`, `scripts/bench_compound_semantic_impact.py`, `scripts/bench_perf_daemon_vs_cli.py`, and `scripts/bench_llm_ab_prompts.py` all use index metadata from `--index` rather than a direct `--model` flag.
+- 2026-03-06: Verified that `scripts/bench_dep_indexes.py` already supports `--model`, so dependency-scoped evaluation does not require extra harness work.
+- 2026-03-06: Verified the repo keeps tracked benchmark inputs under `benchmarks/` and untracked run artifacts under `benchmark/`; the benchmark phases should continue to use `benchmark/cache-root`, `benchmark/runs/`, and `benchmark/corpora/`.
+
+### Immediate Next Steps (Phase 0)
+- Record the Jina license decision before considering any default-model change.
+- Keep using the existing `repo:django-bge` semantic index for daemon-mode query benchmarks because it already identifies as `BAAI/bge-large-en-v1.5` on the Django corpus.
+- Rebuild the BGE Django baseline under `repo:django-bge15` only for fresh build-time / peak-RSS comparisons or if the daemon-side quality deltas are close enough that we need stricter rerun parity.
+
+**Deliverables**
+- Locked model/index naming convention for BGE vs Jina benchmark runs.
+- BGE baseline reports archived under `benchmark/runs/`.
+- Explicit license/default policy recorded in this plan.
+
+**Key tasks**
+- [ ] Decide and record the license outcome:
+  - `blocked_default`
+  - `opt_in_only`
+  - `commercially_licensed`
+- [ ] Build and time the BGE Django semantic index:
+  ```bash
+  /usr/bin/time -l uv run tldrf semantic index \
+    --cache-root benchmark/cache-root \
+    --index repo:django-bge15 \
+    --lang python \
+    --model bge-large-en-v1.5 \
+    --rebuild \
+    benchmark/corpora/django
+  ```
+- [ ] Run the BGE retrieval-quality baseline:
+  ```bash
+  uv run python scripts/bench_retrieval_quality.py \
+    --corpus django \
+    --cache-root benchmark/cache-root \
+    --index repo:django-bge15 \
+    --ks 5,10
+  ```
+- [ ] Run the BGE lane2 retrieval baseline:
+  ```bash
+  uv run python scripts/bench_retrieval_quality.py \
+    --corpus django \
+    --cache-root benchmark/cache-root \
+    --index repo:django-bge15 \
+    --ks 5,10 \
+    --lane2-abstain-threshold 0.35 \
+    --lane2-rerank \
+    --lane2-rerank-top-n 8 \
+    --lane2-max-latency-ms-p50-ratio 1.10 \
+    --lane2-max-payload-tokens-median-ratio 0.90
+  ```
+
+**Acceptance**
+- Baseline BGE artifacts exist for index build time, retrieval quality, and lane2 retrieval quality.
+- License status is explicit before any default-model decision is considered.
+
+## Phase 1: Model Profile Contract (Registry + Metadata)
+
+**Goals**
+- Make Jina-specific behavior representable in code before touching embedding flow.
+
+### Tests To Write First (Red)
+
+- [ ] Add `tests/test_semantic_model_profiles.py`:
+  - assert `SUPPORTED_MODELS["jina-code-0.5b"]` exists
+  - assert `hf_name == "jinaai/jina-code-embeddings-0.5b"`
+  - assert `dimension == 896`
+  - assert query prefix/instruction matches the locked nl2code query prompt
+  - assert document prefix/instruction matches `Candidate code snippet:\n`
+  - assert `tokenizer_kwargs["padding_side"] == "left"`
+- [ ] Add `tests/test_semantic_model_registry_helpers.py`:
+  - `_resolve_hf_model_name("jina-code-0.5b")` resolves correctly
+  - `_canonical_model_id(...)` round-trips both key and HF id
+  - `_model_dimension("jina-code-0.5b") == 896`
+  - BGE still resolves to 1024 and keeps its current query prefix contract
+
+### Green Implementation
+
+- [ ] Extend `SUPPORTED_MODELS` in `tldr/semantic.py` with a richer model profile for:
+  - `bge-large-en-v1.5`
+  - `all-MiniLM-L6-v2`
+  - `jina-code-0.5b`
+- [ ] Add model-profile helpers, for example:
+  - `_model_profile(model_name)`
+  - `_query_prefix_for_model(model_name)`
+  - `_document_prefix_for_model(model_name)`
+  - `_sentence_transformer_kwargs_for_model(model_name)`
+- [ ] Keep metadata fields backward compatible:
+  - `model`
+  - `dimension`
+  - `count`
+
+**Acceptance**
+- Jina is selectable by model key and canonical HF id.
+- Existing BGE and MiniLM lookups continue to work unchanged.
+
+### Running Log (Phase 1)
+- 2026-03-06: Added a richer `SUPPORTED_MODELS` contract in `tldr/semantic.py` for BGE, MiniLM, and Jina, including query/document prefixes plus model-specific tokenizer kwargs.
+- 2026-03-06: Added registry/helper coverage for canonical HF ids, dimensions, and the locked BGE/Jina prefix contracts.
+
+### Gotchas / Learnings (Phase 1)
+- Backward compatibility is easiest when metadata continues to store canonical HF ids; keyed aliases stay an input concern only.
+- The new registry contract can stay dict-based for now; a dataclass refactor is not required to express model-specific behavior.
+
+## Phase 2: Query/Document Instruction Routing In The Embedding Pipeline
+
+**Goals**
+- Apply the right instruction at the right stage:
+  - query prefix at search time
+  - passage prefix at index time
+
+### Running Log (Phase 2)
+- 2026-03-06: `compute_embedding()` currently treats every text as a generic embedding input and `_semantic_unit_search()` hardcodes the BGE query prefix at one callsite.
+- 2026-03-06: `build_semantic_index()` currently batches `build_embedding_text(unit)` directly, so Jina would silently miss the required document instruction without this phase.
+- 2026-03-06: Added `build_document_embedding_text()` and `build_query_embedding_text()` and wired `build_semantic_index()` / `_semantic_unit_search()` through them.
+- 2026-03-06: Extended isolated semantic-index coverage so the Jina path exercises a real 896-dimensional dummy embedding shape.
+
+### Gotchas / Learnings (Phase 2)
+- Keeping `compute_embedding()` generic avoids hiding query/document semantics inside the model loader.
+- Search-time mismatch checks should happen before FAISS search and should fail on both metadata-vs-model and query-vector-vs-index dimension mismatches.
+
+### Tests To Write First (Red)
+
+- [ ] Add `tests/test_semantic_instruction_routing.py`:
+  - Jina document embedding prepends `Candidate code snippet:\n`
+  - Jina query embedding prepends `Find the most relevant code snippet given the following query:\n`
+  - BGE query embedding still prepends `Represent this code search query: `
+  - BGE document embedding remains unprefixed
+- [ ] Extend `tests/test_semantic_index_isolated.py`:
+  - replace the fixed 3-dimensional `DummyModel` with a configurable dummy so the Jina path is exercised with `dim=896`
+  - assert metadata dimension follows the produced embedding shape
+  - assert search/index mismatch errors still fire when metadata model differs
+- [ ] Add `tests/test_semantic_index_rebuild_guards.py`:
+  - indexing BGE artifacts and then attempting Jina without `--rebuild` raises the expected model mismatch
+  - querying a BGE-built index with Jina raises the expected model/dimension mismatch
+
+### Green Implementation
+
+- [ ] Split embedding text preparation into explicit helpers, for example:
+  - `build_document_embedding_text(unit, model_name)`
+  - `build_query_embedding_text(query, model_name)`
+- [ ] Update `build_semantic_index()` to batch document-prefixed text per model profile.
+- [ ] Update `_semantic_unit_search()` / query embedding path to use model-specific query text.
+- [ ] Keep FAISS dimension validation intact so old indexes fail fast and clearly.
+
+**Acceptance**
+- Jina indexes store 896-dimensional metadata and use the correct document/query instructions.
+- BGE behavior remains unchanged.
+
+## Phase 3: Loader Semantics (Left Padding, Caching, Fallback)
+
+**Goals**
+- Ensure the Jina model is loaded in a way that matches its decoder/last-token pooling requirements.
+
+### Tests To Write First (Red)
+
+- [ ] Add `tests/test_semantic_model_loading.py`:
+  - monkeypatch `sentence_transformers.SentenceTransformer` and assert Jina load calls include `tokenizer_kwargs={"padding_side": "left"}`
+  - assert BGE and MiniLM do not force left-padding
+  - assert model cache invalidates correctly when switching `(model, device)`
+- [ ] Add `tests/test_semantic_model_cache_keys.py` if the current global cache variables become insufficient once model kwargs differ by profile.
+- [ ] If the sentence-transformers path proves insufficient, add tests first for a tiny adapter contract:
+  - `.encode(str | list[str], normalize_embeddings=True, batch_size=...) -> np.ndarray`
+
+### Green Implementation
+
+- [ ] Update `get_model()` so model-specific kwargs are passed into `SentenceTransformer(...)`.
+- [ ] Keep existing download confirmation/device behavior intact.
+- [ ] If runtime testing shows sentence-transformers cannot make Jina correct, add a minimal internal adapter using `transformers` while preserving the existing `get_model(...).encode(...)` call pattern used elsewhere.
+
+**Acceptance**
+- Jina load path is explicit, tested, and not silently sharing a stale BGE-loaded model instance.
+
+### Running Log (Phase 3)
+- 2026-03-06: Verified the local `sentence-transformers` constructor already accepts `tokenizer_kwargs`, so Jina left-padding can stay on the existing load path.
+- 2026-03-06: Updated `get_model()` cache identity to include model-specific loader kwargs in addition to `(hf_name, device)`.
+
+### Gotchas / Learnings (Phase 3)
+- Caching only on `(hf_name, device)` is too weak once loader kwargs differ by profile.
+- No dedicated adapter is needed yet; keep that as a fallback only if runtime behavior disproves the `SentenceTransformer(..., tokenizer_kwargs=...)` path.
+
+## Phase 4: CLI, Daemon, and Documentation Wiring
+
+**Goals**
+- Make Jina discoverable and configurable without making it the default yet.
+
+### Running Log (Phase 4)
+- 2026-03-06: Updated CLI help text to advertise Jina as an opt-in model and warn that switching models requires a rebuild.
+- 2026-03-06: Wired daemon-triggered semantic indexing to honor `semantic.model` config while leaving search index-driven by default to avoid accidental config/index mismatches.
+- 2026-03-06: Updated `README.md`, `docs/TLDR.md`, and `benchmarks/README.md` with opt-in Jina guidance, rebuild requirements, and the non-commercial license caveat.
+
+### Gotchas / Learnings (Phase 4)
+- Auto-applying daemon config `model` to search would create surprising failures against existing BGE-built indexes; config should drive indexing, not override search unless explicitly requested.
+- Argparse wraps long model names across lines, so help-text tests need normalization before asserting on `jina-code-0.5b`.
+
+### Tests To Write First (Red)
+
+- [ ] Add `tests/test_cli_semantic_model_flags.py`:
+  - `semantic index --model jina-code-0.5b` parses successfully
+  - help text includes the Jina model key
+- [ ] Add `tests/test_daemon_semantic_model_config.py`:
+  - `_load_semantic_config()` accepts `model: "jina-code-0.5b"`
+  - daemon defaults remain `bge-large-en-v1.5` before the rollout phase
+- [ ] Add or extend docs-smoke tests only if the repo already has a pattern for them; otherwise keep docs validation manual.
+
+### Green Implementation
+
+- [ ] Update `tldr/cli.py` help text to list Jina alongside BGE and MiniLM.
+- [ ] Update `tldr/daemon/core.py` semantic config comments/defaults to support Jina selection without flipping the default yet.
+- [ ] Update docs:
+  - `README.md`
+  - `docs/TLDR.md`
+  - `benchmarks/README.md`
+- [ ] Add an explicit migration note:
+  - Jina requires full semantic reindex due to dimension change
+  - license is non-commercial unless separately licensed
+
+**Acceptance**
+- Users can select Jina from CLI/config.
+- Docs state the reindex requirement and license caveat.
+
+## Phase 5: Required Benchmark Runs (BGE Baseline vs Jina Candidate)
+
+**Goals**
+- Prove or disprove the migration with the local benchmark harness, not just unit tests.
+- Run repo-scale comparison workloads through the daemon wherever the harness supports it so the evidence matches the intended production path.
+
+### Immediate Next Steps (Phase 5)
+- Run the deterministic red/green suite before launching long benchmark sessions so benchmark failures do not mask contract regressions.
+- Use `repo:django-bge` as the current daemon/query baseline and `repo:django-jina05b` as the Jina candidate; reserve `repo:django-bge15` for fresh rebuild timing and strict rerun parity only.
+- Treat daemon mode as the canonical protocol for repo-scale query runs (`retrieval`, `token efficiency`, `compound semantic+impact`, `perf`).
+- Treat index-build timing/RSS and dependency-scoped semantic comparison as explicit CLI-only exceptions until daemon-backed equivalents exist.
+- Run perf as a semantic-focused microbench (`--commands semantic_search --include-semantic`) rather than the broad default command set so the latency row reflects the model swap instead of unrelated `tree`/`structure` work.
+- Use `scripts/bench_structured_retrieval.py` for deterministic exact-target tie-breaker runs against `rg`, `repo:django-bge`, and `repo:django-jina05b`; this is the canonical path for the optional `Structured retrieval F1` row.
+
+### Gotchas / Learnings (Phase 5)
+- Most benchmark runners do not take `--model`; the semantic model is whatever is already materialized behind the chosen `--index`.
+- `scripts/bench_dep_indexes.py` is the exception and can compare BGE vs Jina directly without prebuilding separate repo indexes.
+- `scripts/bench_retrieval_quality.py`, `scripts/bench_token_efficiency.py`, and `scripts/bench_compound_semantic_impact.py` now need `--use-daemon` for the migration's canonical evidence path.
+- `scripts/bench_dep_indexes.py` is still CLI-oriented today; treat it as supplementary until it is daemonized or replaced with an equivalent daemon-backed dependency benchmark.
+- Index build timing is intentionally CLI-only. There is no meaningful daemon-mode substitute for `semantic index`, so `/usr/bin/time -l uv run tldrf semantic index ...` remains the source of truth for build-time and peak-RSS evidence.
+- Jina benchmarking should prewarm the model cache or set `TLDR_AUTO_DOWNLOAD=1`; the first unattended run failed at the interactive model-download prompt.
+- Benchmark daemon startup must use a fresh foreground subprocess. The previous helper path (`start_daemon(... foreground=False)`) produced `Empty response from daemon` during semantic search, while a foreground daemon launched in its own process handled the same requests correctly.
+- The retrieval benchmark had a loop-scoping regression during daemonization; it was fixed before collecting migration evidence so per-query aggregation now covers the full query set instead of only the final query.
+- The existing `repo:django-bge` semantic index is good enough for the daemon-side BGE query baseline because its metadata already locks the corpus/model pair. Keep `repo:django-bge15` for fresh-build comparisons instead of blocking the whole matrix on a redundant rebuild.
+- On Django, Jina is clearly better in plain semantic retrieval but not uniformly better once lane2/rerank heuristics are enabled. The gate cannot rely on the semantic-only win alone.
+- The broad perf microbench was dominated by slow non-semantic commands (`tree` in particular), so it is not a good default-model latency proxy for this migration. Use the new semantic-only command filter for the canonical perf row.
+- The new structured-retrieval harness resolves exact symbol targets from the existing Django retrieval suite deterministically, but the first real run only yielded `45` scoreable symbol queries plus `3` negatives; `7` queries were ambiguous and `5` were unsupported module-level targets.
+- Structured retrieval F1 strongly favors exact-match backends like native `rg`. It is useful as a capability-gap metric, but it should not override the higher-level semantic retrieval gains when the product question is concept search rather than exact definition lookup.
+
+### Running Log (Phase 5)
+- 2026-03-06: Added `--use-daemon` support to the retrieval, token-efficiency, and compound benchmark runners and switched the perf runner onto the same benchmark daemon helper.
+- 2026-03-06: Replaced the benchmark daemon helper with a foreground subprocess launcher after reproducing `semantic search` failures on the old background/fork path.
+- 2026-03-06: Verified daemon-mode smokes for retrieval, token efficiency, and compound against the existing `repo:django` semantic index before launching the migration matrix.
+- 2026-03-06: Confirmed `repo:django-bge15` only had structural artifacts (`call_graph.json`) and required a fresh semantic rebuild before any BGE-vs-Jina comparison.
+- 2026-03-06: Archived the daemon-mode BGE query baseline from `repo:django-bge`:
+  - retrieval: `benchmark/runs/20260306-101803Z-retrieval-django-bge-daemon.json`
+  - lane2 retrieval: `benchmark/runs/20260306-101803Z-retrieval-django-bge-lane2-daemon.json`
+  - token efficiency: `benchmark/runs/20260306-101949Z-token-efficiency-django-bge-daemon.json`
+  - compound semantic+impact: `benchmark/runs/20260306-102247Z-compound-semantic-impact-django-bge-daemon.json`
+- 2026-03-06: Recorded current BGE daemon baseline metrics:
+  - semantic MRR@10 `0.6022`, Recall@5 `0.7719`, Recall@10 `0.7895`, Precision@5 `0.1544`
+  - hybrid_rrf MRR@10 `0.8684`, Recall@10 `1.0000`
+  - lane2 MRR@10 `0.8741`
+  - token-efficiency MRR @1000: semantic `0.6124`, hybrid_rrf `0.8597`
+  - compound TTE p50 ratio `1.0250`
+- 2026-03-06: Started the Jina Django semantic build in `tmux` session `jina-bench-jina05b-build`; artifact writes are expected only after the in-memory embedding pass completes.
+- 2026-03-06: Completed the Jina Django semantic build:
+  - log: `benchmark/logs/20260306-101553Z-django-jina05b-semantic.log`
+  - artifacts: `repo:django-jina05b`, model `jinaai/jina-code-embeddings-0.5b`, dimension `896`, count `35712`
+  - wall time `692.57s`
+  - max RSS `3360096256` bytes
+- 2026-03-06: Archived Jina daemon retrieval artifacts:
+  - retrieval: `benchmark/runs/20260306-103455Z-retrieval-django-jina05b-daemon.json`
+  - lane2 retrieval: `benchmark/runs/20260306-103542Z-retrieval-django-jina05b-lane2-daemon.json`
+  - token efficiency: `benchmark/runs/20260306-103645Z-token-efficiency-django-jina05b-daemon.json`
+- 2026-03-06: Recorded current Jina daemon metrics:
+  - semantic MRR@10 `0.7023`, Recall@5 `0.8596`, Recall@10 `0.8772`, Precision@5 `0.1719`
+  - hybrid_rrf MRR@10 `0.8686`, Recall@10 `1.0000`
+  - lane2 MRR@10 `0.8417`
+  - token-efficiency MRR @1000: semantic `0.7048`, hybrid_rrf `0.8647`
+- 2026-03-06: Archived Jina compound semantic+impact artifact `benchmark/runs/20260306-103725Z-compound-semantic-impact-django-jina05b-daemon.json` with:
+  - compound TTE p50 ratio `1.1361`
+  - same `partial_rate` as BGE (`0.9167`)
+  - identical retrieval overlap / impact caller Jaccard (`1.0`), so the regression is latency/payload rather than correctness drift
+- 2026-03-06: Archived semantic-only BGE perf baselines:
+  - `benchmark/runs/20260306-103913Z-perf-daemon-vs-cli-django-bge-semantic.json` (`iterations=10`)
+  - `benchmark/runs/20260306-104233Z-perf-daemon-vs-cli-django-bge-semantic-i3.json` (`iterations=3`)
+  - current concise reference row: daemon p50 `135.7ms`, daemon p95 `138.8ms`, CLI p50 `6929.8ms`, speedup `51.1x`
+- 2026-03-06: Abandoned the original all-command perf run for `repo:django-bge` because the `tree` command dominated runtime and did not isolate model-driven latency. The canonical perf rerun should use `scripts/bench_perf_daemon_vs_cli.py --commands semantic_search --include-semantic`.
+- 2026-03-06: Patched the compound/perf benchmark reports to persist index/model provenance before collecting the remaining Jina artifacts.
+- 2026-03-06: Attempted matching semantic-only Jina perf runs at `iterations=10` and `iterations=3`, but both remained materially slower/heavier than the BGE baseline and were stopped instead of spending more benchmark time on repeated CLI model reloads. Keep this as a CLI/startup operational warning rather than a daemon-query conclusion.
+- 2026-03-06: Closed the daemon-query latency gap with `benchmark/runs/20260306-adhoc-daemon-semantic-latency-bge-vs-jina.json` (`iterations=10`, query `entry implementation`):
+  - BGE daemon semantic search: mean `159.8ms`, p50 `150.2ms`, p95 `250.2ms`
+  - Jina daemon semantic search: mean `174.6ms`, p50 `166.5ms`, p95 `286.4ms`
+  - steady-state daemon delta: Jina is about `+16.2ms` / `+10.8%` at p50 and `+36.2ms` / `+14.4%` at p95, which is modest compared with the larger startup/build penalties
+- 2026-03-06: Added `scripts/bench_structured_retrieval.py` and targeted tests to score exact structured retrieval across `rg` and daemon-backed semantic indexes.
+- 2026-03-06: Ran the first Django structured-retrieval comparison artifact `benchmark/runs/20260306-182147Z-structured-retrieval-django.json` with:
+  - query set: `32` total (`31` positive exact-definition targets, `1` negative), daemon-backed for `repo:django-bge` and `repo:django-jina05b`
+  - `rg-native` micro F1 `0.9841` (`tp=31`, `fp=1`, `fn=0`), p50 latency `84.8ms`
+  - BGE micro F1 `0.1602` (`tp=27`, `fp=279`, `fn=4`), p50 latency `142.1ms`
+  - Jina micro F1 `0.1520` (`tp=26`, `fp=285`, `fn=5`), p50 latency `140.3ms`
+  - interpretation: this exact-match suite is strongly lexical-friendly, so `rg-native` dominates. Within the semantic backends, BGE slightly beats Jina on micro F1 while Jina is only marginally faster on p50.
+- 2026-03-06: Extended `scripts/bench_structured_retrieval.py` with opt-in hybrid backends (`--include-hybrid`) that project hybrid file hits back to structured unit predictions via semantic-unit rows from the same files.
+- 2026-03-06: Ran the behavior-oriented Django structured-retrieval comparison artifact `benchmark/runs/20260306-185707Z-structured-retrieval-django.json` with:
+  - query set: `17` total (`16` positive behavior-oriented targets, `1` negative), daemon-backed for `repo:django-bge` and `repo:django-jina05b`, `top_k=5`, `--include-hybrid`
+  - `rg-native` micro F1 `0.0217` (`tp=1`, `fp=75`, `fn=15`), p50 latency `87.3ms`
+  - BGE semantic micro F1 `0.1458` (`tp=7`, `fp=73`, `fn=9`), p50 latency `169.5ms`
+  - Jina semantic micro F1 `0.1053` (`tp=5`, `fp=74`, `fn=11`), p50 latency `185.9ms`
+  - BGE hybrid-projected micro F1 `0.1584` (`tp=8`, `fp=77`, `fn=8`), p50 latency `422.9ms`
+  - Jina hybrid-projected micro F1 `0.1188` (`tp=6`, `fp=79`, `fn=10`), p50 latency `438.5ms`
+  - interpretation: for concept-style exact-target recovery, `rg-native` is not competitive. Semantic and hybrid both beat lexical `rg` by a wide margin, and hybrid gives both models a small lift over semantic-only, but BGE still beats Jina on this stricter structured row.
+  - concrete examples:
+    - BGE hybrid recovered `SB13` (`django.contrib.auth.decorators.py.login_required`) while Jina hybrid still missed it, reinforcing the earlier ranking-behavior difference rather than suggesting a migration bug.
+    - Jina hybrid recovered behavior targets that semantic-only missed, including `SB03` (`technical_500_response`), `SB09` (`atomic`), and `SB16` (`QuerySet`).
+  - gotcha: these hybrid latencies are benchmark-harness latencies for `hybrid file retrieval + semantic unit projection`, not raw hybrid file-search latency.
+- 2026-03-06: Reran the same behavior-oriented structured suite with `--hybrid-no-result-guard rg_empty` in artifact `benchmark/runs/20260306-190233Z-structured-retrieval-django.json`:
+  - semantic-only rows stayed effectively unchanged
+  - both hybrid rows collapsed to empty predictions for every positive query: BGE hybrid micro F1 `0.0000` (`tp=0`, `fp=0`, `fn=16`), Jina hybrid micro F1 `0.0000` (`tp=0`, `fp=0`, `fn=16`)
+  - negative-query suppression did work: `SB17` hybrid false positives dropped from `5` to `0` for both BGE and Jina
+  - interpretation: `rg_empty` is too aggressive for this behavior-oriented suite because the current lexical `rg_pattern`s are not reliable guards for concept-style queries. Do not use this guarded artifact as the main hybrid quality signal.
+  - immediate next step if we want a production-leaning guarded hybrid row: either curate guard-quality `rg_pattern`s per behavior query or evaluate a softer hybrid guard than strict `rg_empty`.
+
+### Tier 1: Direct Embedding Quality (Must Run)
+
+- [ ] Build the Jina Django semantic index:
+  ```bash
+  /usr/bin/time -l uv run tldrf semantic index \
+    --cache-root benchmark/cache-root \
+    --index repo:django-jina05b \
+    --lang python \
+    --model jina-code-0.5b \
+    --rebuild \
+    benchmark/corpora/django
+  ```
+- [ ] Run retrieval quality against BGE and Jina indexes:
+  ```bash
+  uv run python scripts/bench_retrieval_quality.py \
+    --corpus django \
+    --cache-root benchmark/cache-root \
+    --index repo:django-bge \
+    --ks 5,10 \
+    --use-daemon
+
+  uv run python scripts/bench_retrieval_quality.py \
+    --corpus django \
+    --cache-root benchmark/cache-root \
+    --index repo:django-jina05b \
+    --ks 5,10 \
+    --use-daemon
+  ```
+  Read from the same report:
+  - `results.agg_positive.semantic`
+  - `results.agg_positive.hybrid_rrf`
+  - `results.agg_negative.*` for false-positive behavior
+- [ ] Run lane2 retrieval for both models:
+  ```bash
+  uv run python scripts/bench_retrieval_quality.py \
+    --corpus django \
+    --cache-root benchmark/cache-root \
+    --index repo:django-bge \
+    --ks 5,10 \
+    --use-daemon \
+    --lane2-abstain-threshold 0.35 \
+    --lane2-rerank \
+    --lane2-rerank-top-n 8 \
+    --lane2-max-latency-ms-p50-ratio 1.10 \
+    --lane2-max-payload-tokens-median-ratio 0.90
+
+  uv run python scripts/bench_retrieval_quality.py \
+    --corpus django \
+    --cache-root benchmark/cache-root \
+    --index repo:django-jina05b \
+    --ks 5,10 \
+    --use-daemon \
+    --lane2-abstain-threshold 0.35 \
+    --lane2-rerank \
+    --lane2-rerank-top-n 8 \
+    --lane2-max-latency-ms-p50-ratio 1.10 \
+    --lane2-max-payload-tokens-median-ratio 0.90
+  ```
+- [ ] Run dependency benchmarks for both models:
+  ```bash
+  uv run python scripts/bench_dep_indexes.py \
+    --dep requests,urllib3 \
+    --lang python \
+    --model bge-large-en-v1.5
+
+  uv run python scripts/bench_dep_indexes.py \
+    --dep requests,urllib3 \
+    --lang python \
+    --model jina-code-0.5b
+  ```
+
+### Tier 2: Downstream Impact (Should Run)
+
+- [ ] Run token-efficiency retrieval benchmarks for both models:
+  ```bash
+  uv run python scripts/bench_token_efficiency.py \
+    --corpus django \
+    --mode retrieval \
+    --cache-root benchmark/cache-root \
+    --index repo:django-bge \
+    --budgets 500,1000,2000,5000 \
+    --use-daemon
+
+  uv run python scripts/bench_token_efficiency.py \
+    --corpus django \
+    --mode retrieval \
+    --cache-root benchmark/cache-root \
+    --index repo:django-jina05b \
+    --budgets 500,1000,2000,5000 \
+    --use-daemon
+  ```
+- [ ] Run compound semantic+impact for both models:
+  ```bash
+  uv run python scripts/bench_compound_semantic_impact.py \
+    --corpus django \
+    --cache-root benchmark/cache-root \
+    --index repo:django-bge \
+    --budget-tokens 2000 \
+    --k 8 \
+    --query-limit 12 \
+    --use-daemon \
+    --retrieval-mode hybrid \
+    --no-result-guard rg_empty \
+    --impact-depth 3 \
+    --impact-limit 3 \
+    --impact-language python \
+    --lane2-abstain-threshold 0.35 \
+    --lane2-rerank \
+    --lane2-rerank-top-n 8
+
+  uv run python scripts/bench_compound_semantic_impact.py \
+    --corpus django \
+    --cache-root benchmark/cache-root \
+    --index repo:django-jina05b \
+    --budget-tokens 2000 \
+    --k 8 \
+    --query-limit 12 \
+    --use-daemon \
+    --retrieval-mode hybrid \
+    --no-result-guard rg_empty \
+    --impact-depth 3 \
+    --impact-limit 3 \
+    --impact-language python \
+    --lane2-abstain-threshold 0.35 \
+    --lane2-rerank \
+    --lane2-rerank-top-n 8
+  ```
+### Tier 4: Optional LLM Validation (Last Phase Only)
+
+- [ ] Only after deterministic retrieval/perf evidence is in place, optionally run prompt generation for each model/index:
+  ```bash
+  uv run python scripts/bench_llm_ab_prompts.py \
+    --corpus django \
+    --cache-root benchmark/cache-root \
+    --index repo:django-bge \
+    --budget-tokens 2000
+
+  uv run python scripts/bench_llm_ab_prompts.py \
+    --corpus django \
+    --cache-root benchmark/cache-root \
+    --index repo:django-jina05b \
+    --budget-tokens 2000
+  ```
+- [ ] Optionally run structured answer scoring for both prompt packets:
+  ```bash
+  uv run python scripts/bench_llm_ab_run.py \
+    --mode structured \
+    --prompts <bge-prompts.jsonl> \
+    --provider <provider> \
+    --model <answer-model>
+
+  uv run python scripts/bench_llm_ab_run.py \
+    --mode structured \
+    --prompts <jina-prompts.jsonl> \
+    --provider <provider> \
+    --model <answer-model>
+  ```
+- [ ] Leave judge-mode A/B as the final optional tie-breaker only if earlier evidence is still ambiguous:
+  ```bash
+  uv run python scripts/bench_llm_ab_run.py \
+    --mode judge \
+    --prompts <bge-prompts.jsonl> \
+    --provider <provider> \
+    --model <answer-model> \
+    --judge-provider <judge-provider> \
+    --judge-model <judge-model>
+
+  uv run python scripts/bench_llm_ab_run.py \
+    --mode judge \
+    --prompts <jina-prompts.jsonl> \
+    --provider <provider> \
+    --model <answer-model> \
+    --judge-provider <judge-provider> \
+    --judge-model <judge-model>
+  ```
+
+### Tier 3: Performance Regression (Must Run)
+
+- [ ] Record index build wall time and max RSS from `/usr/bin/time -l` for both model builds.
+- [ ] Run semantic latency microbench for both indexes:
+  ```bash
+  uv run python scripts/bench_perf_daemon_vs_cli.py \
+    --corpus django \
+    --lang python \
+    --cache-root benchmark/cache-root \
+    --index repo:django-bge \
+    --include-semantic \
+    --commands semantic_search
+
+  uv run python scripts/bench_perf_daemon_vs_cli.py \
+    --corpus django \
+    --lang python \
+    --cache-root benchmark/cache-root \
+    --index repo:django-jina05b \
+    --include-semantic \
+    --commands semantic_search
+  ```
+- [ ] Record:
+  - semantic search p50/p95
+  - daemon vs CLI speedup
+  - index artifact sizes
+
+### Tier 5: Optional Head-to-Head Suite (Nice To Have)
+
+- [ ] Only after Tier 1-3 look promising, add model-specific tool/profile wiring or paired prediction artifacts and run `scripts/bench_head_to_head.py`.
+- [ ] Keep this out of the critical path for the initial opt-in implementation.
+
+**Acceptance**
+- All required benchmark artifacts exist for both BGE and Jina.
+- Reports are comparable by corpus, index id, budget, and answer-model configuration.
+
+## Phase 6: Decision Gate
+
+**Goals**
+- Decide whether Jina should remain opt-in, become the default, or be rejected.
+
+### Immediate Next Steps (Phase 6)
+- Do not finalize the comparison table until both BGE and Jina reports exist for the same corpus and semantic-model identity. The current BGE daemon baseline may come from `repo:django-bge`; use `repo:django-bge15` only where fresh rebuild timing/RSS parity matters.
+- Treat the current code changes as enabling work only; the gate is still pending benchmark evidence plus the license decision.
+- `Structured retrieval F1` is now available as an optional deterministic tie-breaker row. `Judge win rate` remains the final optional phase only if earlier evidence is still ambiguous.
+- Current benchmark signal is already sufficient to block `PROCEED_TO_DEFAULT`: Jina improves plain semantic retrieval, but lane2 and compound regress, and operational cost is clearly higher. At best, the current evidence supports `KEEP_OPT_IN`.
+- Immediate next steps for the structured lane if we need tighter product fidelity:
+  - if we want to keep `rg_empty` in the structured hybrid evaluation, first curate behavior-query guard patterns that actually hit the intended implementation files; the current broad concept patterns suppress nearly all positive queries
+  - if structured hybrid scoring becomes a gating metric, replace the current semantic-unit projection resolver with a per-file symbol resolver so the metric is closer to what a file-first hybrid UX would actually surface
+
+### Required Comparison Table
+
+Fill this table from the archived reports:
+
+| Metric | BGE baseline | Jina | Delta | Decision note |
+| --- | --- | --- | --- | --- |
+| MRR@10 (semantic) | 0.6022 | 0.7023 | +0.1001 | `benchmark/runs/20260306-101803Z-retrieval-django-bge-daemon.json`, `benchmark/runs/20260306-103455Z-retrieval-django-jina05b-daemon.json` |
+| Recall@5 (semantic) | 0.7719 | 0.8596 | +0.0877 | `benchmark/runs/20260306-101803Z-retrieval-django-bge-daemon.json`, `benchmark/runs/20260306-103455Z-retrieval-django-jina05b-daemon.json` |
+| Recall@10 (semantic) | 0.7895 | 0.8772 | +0.0877 | `benchmark/runs/20260306-101803Z-retrieval-django-bge-daemon.json`, `benchmark/runs/20260306-103455Z-retrieval-django-jina05b-daemon.json` |
+| Precision@5 (semantic) | 0.1544 | 0.1719 | +0.0175 | `benchmark/runs/20260306-101803Z-retrieval-django-bge-daemon.json`, `benchmark/runs/20260306-103455Z-retrieval-django-jina05b-daemon.json` |
+| MRR@10 (hybrid_rrf) | 0.8684 | 0.8686 | +0.0001 | `benchmark/runs/20260306-101803Z-retrieval-django-bge-daemon.json`, `benchmark/runs/20260306-103455Z-retrieval-django-jina05b-daemon.json` |
+| Recall@10 (hybrid_rrf) | 1.0000 | 1.0000 | +0.0000 | `benchmark/runs/20260306-101803Z-retrieval-django-bge-daemon.json`, `benchmark/runs/20260306-103455Z-retrieval-django-jina05b-daemon.json` |
+| Lane2 MRR@10 | 0.8741 | 0.8417 | -0.0324 | `benchmark/runs/20260306-101803Z-retrieval-django-bge-lane2-daemon.json`, `benchmark/runs/20260306-103542Z-retrieval-django-jina05b-lane2-daemon.json` |
+| Token-efficiency retrieval MRR @1000 | semantic 0.6124 / hybrid_rrf 0.8597 | semantic 0.7048 / hybrid_rrf 0.8647 | +0.0924 / +0.0050 | `benchmark/runs/20260306-101949Z-token-efficiency-django-bge-daemon.json`, `benchmark/runs/20260306-103645Z-token-efficiency-django-jina05b-daemon.json` |
+| Compound TTE p50 ratio | 1.0250 | 1.1361 | +0.1111 | `benchmark/runs/20260306-102247Z-compound-semantic-impact-django-bge-daemon.json`, `benchmark/runs/20260306-103725Z-compound-semantic-impact-django-jina05b-daemon.json` |
+| Structured retrieval F1 | 0.1602 | 0.1520 | -0.0082 | `benchmark/runs/20260306-182147Z-structured-retrieval-django.json`; `rg-native` on the same run is `0.9841`, so this row is useful for cross-tool sanity checking but is too lexical-friendly to override the primary semantic-retrieval decision |
+| Structured retrieval F1 (behavior suite, semantic) | 0.1458 | 0.1053 | -0.0406 | `benchmark/runs/20260306-185707Z-structured-retrieval-django.json`; on this concept-oriented suite `rg-native` collapses to `0.0217`, so semantic retrieval is clearly buying something real even though BGE still leads Jina |
+| Structured retrieval F1 (behavior suite, hybrid) | 0.1584 | 0.1188 | -0.0396 | `benchmark/runs/20260306-185707Z-structured-retrieval-django.json`; hybrid lifts both models over their semantic-only rows on the same suite, but BGE still wins and the measured latency here includes file-to-symbol projection inside the benchmark harness |
+| Structured retrieval F1 (behavior suite, hybrid, `rg_empty` guard) | 0.0000 | 0.0000 | +0.0000 | `benchmark/runs/20260306-190233Z-structured-retrieval-django.json`; useful only as a guard-sensitivity check. The strict lexical guard suppressed all positive hybrid queries while fixing the negative query, so this should not be treated as the representative hybrid quality row |
+| Judge win rate |  |  |  |  |
+| Dependency MRR (`requests`) |  |  |  |  |
+| Dependency MRR (`urllib3`) |  |  |  |  |
+| Index build time (s) |  | 692.57 |  | Jina build log `benchmark/logs/20260306-101553Z-django-jina05b-semantic.log`; comparable BGE rebuild still pending |
+| Query latency p50 (ms) | 150.2 | 166.5 | +16.2 | `benchmark/runs/20260306-adhoc-daemon-semantic-latency-bge-vs-jina.json`; use this as the current apples-to-apples daemon semantic-search latency row |
+| Query latency p95 (ms) | 250.2 | 286.4 | +36.2 | `benchmark/runs/20260306-adhoc-daemon-semantic-latency-bge-vs-jina.json`; the formal CLI-heavy Jina perf rerun remains unnecessary for the daemon-first decision |
+| Peak RSS (MB) |  | 3360.1 |  | Converted from `3360096256` bytes max RSS in the Jina build log; comparable BGE rebuild still pending |
+
+### Cross-Tool Structured Summary
+
+Use this table when the question is not just "BGE vs Jina?" but "which retrieval mode is actually the right tool for this job?"
+
+**Structured Retrieval Micro F1**
+
+| Suite | `rg-native` | BGE semantic | Jina semantic | BGE hybrid | Jina hybrid | What it says |
+| --- | --- | --- | --- | --- | --- | --- |
+| Exact-definition suite (`benchmark/runs/20260306-182147Z-structured-retrieval-django.json`) | 0.9841 | 0.1602 | 0.1520 |  |  | Exact symbol/definition lookup is a lexical problem first. Use `rg-native`; neither semantic backend is close, and Jina does not beat BGE. |
+| Behavior suite (`benchmark/runs/20260306-185707Z-structured-retrieval-django.json`) | 0.0217 | 0.1458 | 0.1053 | 0.1584 | 0.1188 | Concept-style exact-target recovery is where semantic/hybrid adds value over `rg-native`. Jina is useful relative to `rg-native`, but BGE still wins across both semantic and hybrid. |
+| Behavior suite with hybrid `rg_empty` guard (`benchmark/runs/20260306-190233Z-structured-retrieval-django.json`) | 0.0217 | 0.1458 | 0.1053 | 0.0000 | 0.0000 | The current behavior-query lexical guards are too weak for strict `rg_empty`. This run is a guard-sensitivity check, not a representative hybrid-quality row. |
+
+**Structured Retrieval p50 Latency (ms)**
+
+| Suite | `rg-native` | BGE semantic | Jina semantic | BGE hybrid | Jina hybrid | What it says |
+| --- | --- | --- | --- | --- | --- | --- |
+| Exact-definition suite (`benchmark/runs/20260306-182147Z-structured-retrieval-django.json`) | 84.8 | 142.1 | 140.3 |  |  | `rg-native` is the fastest and best on exact lookup. Jina is only marginally faster than BGE here and still worse on quality. |
+| Behavior suite (`benchmark/runs/20260306-185707Z-structured-retrieval-django.json`) | 87.3 | 169.5 | 185.9 | 422.9 | 438.5 | Semantic beats `rg-native` on quality for concept lookup, but hybrid is substantially slower in this harness because it includes deterministic file-to-symbol projection. |
+| Behavior suite with hybrid `rg_empty` guard (`benchmark/runs/20260306-190233Z-structured-retrieval-django.json`) | 85.2 | 186.5 | 189.8 | 358.0 | 358.3 | The guard reduces hybrid work, but it only looks "faster" because it suppresses nearly all positive results. Do not interpret this as a real hybrid latency win. |
+
+**Cross-Tool Decision Summary**
+
+- `rg-native` is the best tool for exact identifier and definition lookup.
+- BGE semantic or hybrid is the strongest option we have for concept-style structured retrieval on the current Django evidence.
+- Jina is useful relative to `rg-native` on concept-style retrieval, but the current evidence does not show a case where Jina beats BGE on these structured rows.
+- Strict `rg_empty` hybrid guards should not be used with broad behavior-query lexical patterns unless those guard patterns are curated to hit the intended implementation files.
+
+### Defining Structured Retrieval F1
+
+- Treat this as an optional deterministic tie-breaker for retrieval quality, not a replacement for MRR/Recall.
+- Goal: measure whether the retrieved rows resolve to the correct structured code targets, not just whether a relevant file appeared somewhere in the ranking.
+- Score only the top-`k` normalized retrieval rows after deduplication.
+- Record the table row as the micro-averaged F1 over all scored queries. Keep per-query precision, recall, and F1 in the artifact for debugging.
+
+**Normalized Prediction Schema**
+
+Use this normalized object shape for every retrieved row before scoring:
+
+```json
+{
+  "file": "repo/relative/path.py",
+  "qualified_symbol": "package.module.Class.method",
+  "symbol_kind": "function|method|class|module|unknown",
+  "start_line": 123,
+  "end_line": 145,
+  "rank": 1
+}
+```
+
+- `file` is required and must be repo-relative and normalized to `/`.
+- `qualified_symbol` is the primary identity field when present.
+- `symbol_kind`, `start_line`, and `end_line` are supporting fields for debugging and fallback matching.
+- `rank` is not part of the identity key; it is only preserved for auditability.
+
+**Gold Target Schema**
+
+Curated benchmark labels should use the same identity surface, minus rank:
+
+```json
+{
+  "query_id": "django-q001",
+  "targets": [
+    {
+      "file": "django/contrib/admin/options.py",
+      "qualified_symbol": "django.contrib.admin.options.ModelAdmin.get_search_results",
+      "symbol_kind": "method",
+      "start_line": 1181,
+      "end_line": 1207
+    }
+  ]
+}
+```
+
+**Identity Key And Matching**
+
+- Primary key: `(file, qualified_symbol)` when `qualified_symbol` exists in both gold and prediction.
+- Fallback key: `(file, start_line, end_line)` only when symbol identity is unavailable on one or both sides.
+- If neither `qualified_symbol` nor a valid span is available, the row is unscorable and should be excluded from this metric while incrementing an `unscorable_predictions` or `unscorable_gold_targets` counter in the artifact.
+- Deduplicate predictions and gold targets by identity key before counting matches.
+
+**Counting Rules**
+
+- `tp`: predicted identity keys that exactly match a gold identity key for that query.
+- `fp`: predicted identity keys in the scored top-`k` set that do not appear in the gold set.
+- `fn`: gold identity keys not recovered by the scored top-`k` prediction set.
+- Per-query metrics:
+  - `precision = tp / (tp + fp)`
+  - `recall = tp / (tp + fn)`
+  - `f1 = 2 * precision * recall / (precision + recall)`
+- Table metric:
+  - micro-average by summing `tp`, `fp`, and `fn` across all queries first, then computing precision, recall, and F1 from those totals
+  - keep macro-average as a secondary debug row if needed, but do not use it as the Phase 6 comparison row
+
+**Scoring Notes**
+
+- This metric is intentionally stricter than file-level retrieval metrics. Returning the correct file but the wrong function should count as a miss when symbol identity is available.
+- For queries with multiple valid answers, include every acceptable target in the gold `targets` array.
+- If a query is intentionally file-level only, omit `qualified_symbol` from the gold label and force span-based matching for that query.
+- Do not use LLM judgment in this row; this is a deterministic set-overlap metric.
+- Current first-pass Django suite is intentionally definition-oriented so `rg-native` can participate fairly without AST heuristics. Treat it as a cross-tool exact-match sanity check, not as the primary signal for the BGE-vs-Jina semantic default decision.
+- Second-pass behavior-oriented Django suite uses broader natural-language queries and broader `rg_pattern`s to test concept search against exact structured targets. Treat this as the more representative cross-tool check for whether semantic or hybrid retrieval adds product value over native `rg`.
+- Hybrid structured runs currently score a deterministic projection:
+  - retrieve top files with `retrieval_mode=hybrid`
+  - run semantic unit retrieval for the same query
+  - keep unit rows whose files appear in the hybrid top-file set
+  - sort by hybrid file rank first, semantic unit rank second, then score the resulting structured rows
+- This makes the hybrid row useful today, but it is still an approximation of a file-first UX. If the hybrid structured row becomes gating, replace the projection with a per-file symbol resolver.
+- `rg_empty` guard is only as good as the lexical guard pattern. On the current behavior-oriented suite, enabling `rg_empty` suppressed both hybrid backends to zero because the broad concept `rg_pattern`s rarely produced lexical matches even when the semantic answer was recoverable. Use this guard only with query labels whose lexical patterns are known-good.
+- Immediate next step if this row is implemented: add a dedicated benchmark artifact that persists `per_query`, `micro_totals`, `micro_precision`, `micro_recall`, `micro_f1`, and unscorable-count diagnostics for both BGE and Jina daemon runs.
+
+### Interpreting Compound TTE
+
+- `tte_ms_p50_ratio` is `compound median time-to-evidence / sequential median time-to-evidence`.
+- `1.0` means the compound path is equally efficient to running `semantic_search + bounded per-row impact_analysis` sequentially.
+- `>1.0` means the compound feature adds overhead relative to the sequential baseline; `<1.0` means it is actually buying back time.
+- BGE at `1.0250` means compound is about `2.5%` slower than sequential on the median query. Jina at `1.1361` means compound is about `13.6%` slower than sequential on the median query.
+- This metric is a relative efficiency check, not an absolute latency comparison across models. Jina compound p50 is still lower in absolute terms than BGE compound p50, but it is a worse trade relative to Jina's own faster sequential baseline.
+- Product rule: do not let this metric alone block the default-model decision unless `compound-impact` is part of the default user path. Use it as a secondary gate: block the default flip only if compound shows correctness drift or materially worse user-visible latency for a feature we intend to make first-class by default.
+- Current interpretation: this is an efficiency regression, not a correctness regression, because retrieval overlap and impact-caller Jaccard both stayed at `1.0`. It supports `KEEP_OPT_IN` for Jina and argues against advertising compound as a default-path win, but lane2 regression and operational/build cost remain the stronger blockers for any default flip.
+
+### Gate Rules
+
+- `PROCEED_TO_DEFAULT` only if all are true:
+  - license is not a blocker
+  - semantic MRR improves by at least 5 percent relative or hybrid quality improves materially with no major regression elsewhere
+  - query latency does not regress by more than 2x on CPU/MPS
+  - no correctness regressions in deterministic tests
+- `KEEP_OPT_IN` if:
+  - quality is better or neutral
+  - performance is acceptable
+  - but license or rollout risk still blocks default change
+- `ROLL_BACK_JINA` if any are true:
+  - deterministic correctness remains flaky
+  - semantic/hybrid quality regresses materially
+  - CPU latency regresses by more than 2x and Matryoshka/fallback work is not yet justified
+  - license blocks intended usage
+
+### Fallback Option
+
+- If quality is clearly better but CPU performance fails the gate:
+  - run a follow-up spike on Matryoshka truncation
+  - do not change the default in the same PR/implementation wave
+
+**Acceptance**
+- One explicit decision is recorded: `PROCEED_TO_DEFAULT`, `KEEP_OPT_IN`, or `ROLL_BACK_JINA`.
+
+## Phase 7: Rollout (Only If Gate Passes)
+
+**Goals**
+- Safely expose the chosen default and communicate the rebuild requirement.
+
+### Immediate Next Steps (Phase 7)
+- Leave `DEFAULT_MODEL` and daemon defaults untouched until Phase 6 explicitly records `PROCEED_TO_DEFAULT`.
+- If the gate stalls on license or performance, ship the current work as opt-in support and keep the rollout phase open.
+
+### Tests To Write First (Red)
+
+- [ ] Add/extend tests that assert the chosen default model if and only if the gate has passed and the rollout PR intends to flip it.
+- [ ] Add docs/manual validation checklist for fresh-index rebuild behavior.
+
+### Green Implementation
+
+- [ ] Update `DEFAULT_MODEL` in `tldr/semantic.py` only if Phase 6 says `PROCEED_TO_DEFAULT`.
+- [ ] Update daemon default config in `tldr/daemon/core.py`.
+- [ ] Update user-facing docs and examples to match the final decision.
+- [ ] Add a migration note everywhere semantic indexing is documented:
+  - old semantic indexes must be rebuilt
+  - example command:
+    ```bash
+    uv run tldrf semantic index --cache-root <cache-root> --index <index-id> --lang <lang> --model <model> --rebuild <path>
+    ```
+
+**Acceptance**
+- Default selection, docs, and rebuild guidance are all aligned.
+
+## Acceptance Criteria (Summary)
+
+- Deterministic test coverage exists for:
+  - Jina model registry entry
+  - query/document instruction routing
+  - left-padding loader behavior
+  - model/dimension mismatch guards
+  - CLI/daemon model wiring
+- `uv run pytest` passes with the new and updated tests.
+- Benchmark artifacts exist for all required benchmark families named in the migration plan:
+  - retrieval quality
+  - dependency indexes
+  - token efficiency
+  - compound semantic+impact
+  - performance regression
+- Optional last-phase artifacts may also exist for:
+  - LLM A/B
+- The decision gate is explicitly recorded before any default-model flip.
+- If the gate does not pass, Jina support may still ship as opt-in, but BGE remains the default.

--- a/implementations/010-agentic-kimi-vs-native_IMPLEMENTATION_PLAN.md
+++ b/implementations/010-agentic-kimi-vs-native_IMPLEMENTATION_PLAN.md
@@ -1,7 +1,6 @@
 # Agentic Benchmark Plan: Kimi With TLDRF vs Native Tools
 
 - Status: Proposed
-- Owner: TBD
 - Last updated: 2026-03-06
 
 ## Goal
@@ -74,6 +73,13 @@ Model-comparison note:
   - Kimi with native tools plus `tldrf`
 - once that baseline is stable, the same harness can be rerun later with additional models
 
+Instruction-surface note:
+
+- keep the harness / system prompt fixed across both benchmark arms
+- do **not** treat system-prompt editing as a tuning lever for this benchmark
+- tune exactly one canonical instruction document that is intended to graduate into normal everyday usage as well as eval usage
+- explanatory docs may mirror that policy, but they are not independent tuning surfaces
+
 ## Benchmark Source Strategy
 
 This plan intentionally uses two benchmark layers:
@@ -119,7 +125,14 @@ Every agentic benchmark phase should compare at least these two arms:
 - Augmented arm:
   - same native tools
   - plus `tldrf`
-  - plus the repo usage policy from [AGENTS.md](../AGENTS.md) and [docs/llm-tldr-reference-card.md](../docs/llm-tldr-reference-card.md)
+  - plus the single canonical instruction policy
+
+Canonical instruction policy:
+
+- one authoritative instruction document only
+- for now, treat [AGENTS.md](../AGENTS.md) as the canonical source unless and until it is intentionally replaced by a dedicated `skill.md`
+- [docs/llm-tldr-reference-card.md](../docs/llm-tldr-reference-card.md) remains explanatory and should mirror the policy, not diverge from it
+- evals and normal usage should both consume the same canonical instruction policy
 
 The augmented arm is not allowed to replace `rg` for exact lexical lookup.
 
@@ -181,8 +194,8 @@ Purpose:
 
 Gold policy source:
 
-- [AGENTS.md](../AGENTS.md)
-- [docs/llm-tldr-reference-card.md](../docs/llm-tldr-reference-card.md)
+- canonical instruction source: [AGENTS.md](../AGENTS.md)
+- explanatory mirror only: [docs/llm-tldr-reference-card.md](../docs/llm-tldr-reference-card.md)
 
 Required preflight gate before full runs:
 
@@ -222,10 +235,14 @@ Metrics:
 
 If the preflight gate fails, tune in this order:
 
-1. benchmark instructions / system prompt
-2. future `skill.md` or `AGENTS.md` guidance
-3. task examples / few-shot demonstrations
-4. tool wrappers or clearer tool descriptions if the model is still confused
+1. the single canonical instruction document
+2. task examples / few-shot demonstrations that are bundled under that same instruction policy
+3. tool wrappers or clearer tool descriptions if the model is still confused
+
+Do not tune:
+
+- the harness / system prompt as a benchmark-specific workaround
+- multiple competing instruction documents at the same time
 
 Failed preflight runs are invalidation signals, not product evidence:
 
@@ -373,14 +390,20 @@ Likely files to change:
 - [benchmarks/README.md](../benchmarks/README.md)
   - publish the new benchmark family and results
 
+Canonical instruction surface to maintain:
+
+- [AGENTS.md](../AGENTS.md) during the initial benchmark program
+- optional future replacement: a single dedicated `skill.md`
+- if that replacement happens, it must become the sole source of truth for both eval and normal usage
+
 ## Immediate Next Steps
 
 1. Create the OpenRouter provider adapter so Kimi can run inside the existing answer-model harness.
 2. Reuse the current Django `llm_ab` packets and run the smallest possible pilot:
    - Kimi baseline arm
    - Kimi plus `tldrf` arm
-3. Define the preflight tool-usage suite and transcript review gate from `AGENTS.md` and the reference card.
-4. Run the preflight gate and tune the instruction surface until workflow compliance is acceptable.
+3. Define the preflight tool-usage suite from the single canonical instruction source in [AGENTS.md](../AGENTS.md).
+4. Run the preflight gate and tune only that canonical instruction surface until workflow compliance is acceptable.
 5. Define the full tool-choice gold policy suite.
 6. Curate a first batch of local patch/test tasks on Django.
 7. Select the first 20-50 Django-heavy SWE-bench Verified tasks for the external pilot.
@@ -402,12 +425,17 @@ Likely files to change:
   - transcript review
   - workflow-compliance metrics
   - instruction tuning if the agent does not use `tldrf` appropriately
+- 2026-03-06: Locked the instruction-tuning policy:
+  - keep harness/system prompts fixed
+  - tune one canonical instruction document only
+  - treat mirror docs as explanatory, not independent benchmark levers
 
 ## Gotchas / Learnings
 
 - Existing `llm_ab` results are valuable, but they measure prebuilt context packets, not tool-using agents.
 - A strong external benchmark does not remove the need for a local benchmark. Local suites are still the fastest way to tune tool policy, packing, and harness behavior.
 - If the model does not know when to use `tldrf`, the benchmark mostly measures prompt quality, not tool utility. Full runs should be blocked until the preflight gate passes.
+- System-prompt changes would contaminate the comparison. The benchmark should vary tool availability and one canonical instruction policy, not hidden harness behavior.
 - The most realistic winning setup is expected to be policy-combined, not tool-exclusive:
   - `rg` for exact lookup
   - `tldrf` for structure and concept search

--- a/implementations/010-agentic-kimi-vs-native_IMPLEMENTATION_PLAN.md
+++ b/implementations/010-agentic-kimi-vs-native_IMPLEMENTATION_PLAN.md
@@ -5,7 +5,7 @@
 
 ## Goal
 
-Measure whether a smaller, cost-efficient answer model, starting with Kimi on OpenRouter, performs better on real repository work when equipped with `tldrf` than when limited to native lexical tools such as `rg`, `grep`, file reads, and tests.
+Measure whether a smaller, cost-efficient answer model, starting with Kimi CLI, performs better on real repository work when equipped with `tldrf` than when limited to native lexical tools such as `rg`, `grep`, file reads, and tests.
 
 The benchmark must answer the stronger version of the README claim:
 
@@ -51,19 +51,20 @@ Current missing proof:
 
 Preferred benchmark stack for the first real agentic run:
 
-- Answer model / "model user": Kimi on OpenRouter
-- Fallback cheap answer model: DeepSeek on OpenRouter
-- Judge: Claude Sonnet via existing Claude subscription or API
+- Answer model / "model user": Kimi CLI using the existing logged-in local session
+- Optional later fallback model: DeepSeek
+- Judge: Claude Sonnet medium via the existing Claude subscription or API
 
 Important implementation constraint:
 
 - today [scripts/bench_llm_ab_run.py](../scripts/bench_llm_ab_run.py) supports `codex`, `claude_sdk`, `claude_cli`, and `anthropic`
-- using Kimi or DeepSeek in the harness requires adding an OpenAI-compatible / OpenRouter provider adapter first
+- using Kimi in the harness requires adding a Kimi CLI provider adapter or wrapper path first
+- if the current Claude judge path does not expose an explicit medium setting, add or document the closest stable Sonnet-medium-equivalent setting and keep it fixed across runs
 
 Cost note:
 
-- target budget is low double digits for pilot runs
-- exact spend must be verified against current provider pricing before full sweeps
+- target cost is primarily subscription-backed for the answer model because Kimi CLI is already logged in locally
+- incremental cost should mostly come from the Claude judge path and larger external benchmark sweeps
 
 Model-comparison note:
 
@@ -161,7 +162,7 @@ Secondary metrics:
 Judge policy:
 
 - use deterministic tests or scripted oracles wherever possible
-- use Claude Sonnet as judge only when deterministic scoring is not feasible
+- use Claude Sonnet medium as judge only when deterministic scoring is not feasible
 
 ## Phase Plan
 
@@ -179,7 +180,7 @@ Work:
 - run the same Kimi model in two conditions:
   - baseline context arm built from native-tool packets
   - augmented context arm built from `tldrf` packets
-- keep the judge fixed and stronger
+- keep the judge fixed as Claude Sonnet medium
 
 Acceptance:
 
@@ -324,8 +325,8 @@ Initial run:
 
 - 20-50 Django-heavy SWE-bench Verified tasks
 - baseline arm vs augmented arm
-- Kimi as the answer model
-- Claude Sonnet as the judge only where a secondary qualitative read is useful
+- Kimi CLI as the answer model
+- Claude Sonnet medium as the judge only where a secondary qualitative read is useful
 
 Record:
 
@@ -376,7 +377,7 @@ Acceptance:
 Likely files to change:
 
 - [scripts/bench_llm_ab_run.py](../scripts/bench_llm_ab_run.py)
-  - add OpenRouter / OpenAI-compatible provider adapter
+  - add a Kimi CLI provider adapter or wrapper path
   - extend full-run usage accounting
 - New: `scripts/bench_tool_choice.py`
   - add a preflight mode that emits transcript-level workflow-compliance reports
@@ -398,7 +399,7 @@ Canonical instruction surface to maintain:
 
 ## Immediate Next Steps
 
-1. Create the OpenRouter provider adapter so Kimi can run inside the existing answer-model harness.
+1. Create the Kimi CLI provider adapter so the logged-in local Kimi session can run inside the existing answer-model harness.
 2. Reuse the current Django `llm_ab` packets and run the smallest possible pilot:
    - Kimi baseline arm
    - Kimi plus `tldrf` arm
@@ -412,9 +413,9 @@ Canonical instruction surface to maintain:
 
 - 2026-03-06: Created this plan to combine the existing local benchmark stack with a new agentic evaluation goal focused on Kimi-with-`tldrf` vs Kimi-without-`tldrf`.
 - 2026-03-06: Locked the preferred initial model stack as:
-  - answer model: Kimi on OpenRouter
-  - fallback cheap answer model: DeepSeek on OpenRouter
-  - judge: Claude Sonnet
+  - answer model: Kimi CLI
+  - optional later fallback model: DeepSeek
+  - judge: Claude Sonnet medium
 - 2026-03-06: Narrowed the first benchmark pass to a same-model comparison only:
   - Kimi with native tools
   - Kimi with native tools plus `tldrf`
@@ -439,4 +440,5 @@ Canonical instruction surface to maintain:
 - The most realistic winning setup is expected to be policy-combined, not tool-exclusive:
   - `rg` for exact lookup
   - `tldrf` for structure and concept search
-- Cost claims must be treated as variable until provider pricing is rechecked at execution time.
+- Kimi CLI avoids forcing an OpenRouter dependency into the first benchmark pass, which keeps the initial harness closer to the real local workflow we actually want to evaluate.
+- Judge configuration should be pinned exactly once selected. "Claude Sonnet medium" should not drift between pilot and scale-out runs.

--- a/implementations/010-agentic-kimi-vs-native_IMPLEMENTATION_PLAN.md
+++ b/implementations/010-agentic-kimi-vs-native_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,414 @@
+# Agentic Benchmark Plan: Kimi With TLDRF vs Native Tools
+
+- Status: Proposed
+- Owner: TBD
+- Last updated: 2026-03-06
+
+## Goal
+
+Measure whether a smaller, cost-efficient answer model, starting with Kimi on OpenRouter, performs better on real repository work when equipped with `tldrf` than when limited to native lexical tools such as `rg`, `grep`, file reads, and tests.
+
+The benchmark must answer the stronger version of the README claim:
+
+- not just "better context can improve answers"
+- but "a smaller model using `tldrf` as a tool solves repo work better, with fewer tokens, turns, and time, than the same model using native tools alone"
+
+## Primary Hypotheses
+
+1. `tldrf` improves final task outcomes for the same answer model by reducing search space and context pollution.
+2. The best practical policy is not `tldrf`-only. It is:
+   - `rg` first for exact lexical lookup
+   - `tldrf` for structure, blast radius, slices, data flow, and concept lookup
+3. The right evaluation is agentic and end-to-end:
+   - task -> tool choice -> evidence gathering -> answer or patch -> test or oracle
+   - not just retrieval metrics or prebuilt context packets
+
+## What The Repo Already Proves
+
+Existing benchmark infrastructure already measures a meaningful part of the value proposition:
+
+- [benchmarks/README.md](../benchmarks/README.md)
+- [scripts/bench_llm_ab_run.py](../scripts/bench_llm_ab_run.py)
+- [scripts/bench_llm_ab_prompts.py](../scripts/bench_llm_ab_prompts.py)
+- [benchmarks/llm/tasks.json](../benchmarks/llm/tasks.json)
+- [benchmarks/llm/open_ended_tasks.json](../benchmarks/llm/open_ended_tasks.json)
+- [benchmarks/head_to_head/README.md](../benchmarks/head_to_head/README.md)
+
+Current proof surface:
+
+- `tldrf` context can beat `rg` context on Django structural tasks.
+- Open-ended judge runs already support "better context produces better answers."
+- Deterministic retrieval, impact, slice, DFG, and token-efficiency families already exist.
+
+Current missing proof:
+
+- agent-chosen tool use
+- full-run token and turn accounting across the whole task
+- wall-clock time to completion
+- solve rate and time-to-first-passing-test
+- changed-file recall / precision
+
+## Practical Model Stack
+
+Preferred benchmark stack for the first real agentic run:
+
+- Answer model / "model user": Kimi on OpenRouter
+- Fallback cheap answer model: DeepSeek on OpenRouter
+- Judge: Claude Sonnet via existing Claude subscription or API
+
+Important implementation constraint:
+
+- today [scripts/bench_llm_ab_run.py](../scripts/bench_llm_ab_run.py) supports `codex`, `claude_sdk`, `claude_cli`, and `anthropic`
+- using Kimi or DeepSeek in the harness requires adding an OpenAI-compatible / OpenRouter provider adapter first
+
+Cost note:
+
+- target budget is low double digits for pilot runs
+- exact spend must be verified against current provider pricing before full sweeps
+
+Model-comparison note:
+
+- the first version of this benchmark does **not** compare Kimi against a stronger model
+- it compares the same model in two arms:
+  - Kimi with native tools only
+  - Kimi with native tools plus `tldrf`
+- once that baseline is stable, the same harness can be rerun later with additional models
+
+## Benchmark Source Strategy
+
+This plan intentionally uses two benchmark layers:
+
+1. Local repo-native evaluation first
+   - fastest iteration
+   - reuses existing Django suites and scoring harnesses
+   - proves the benchmark design before expensive external runs
+2. External validation second
+   - use SWE-bench Verified first
+   - expand to larger SWE-bench runs only after the local harness and policy are stable
+
+Why SWE-bench Verified is the right external anchor:
+
+- real GitHub issue tasks
+- strong fit for debugging and patching
+- existing hidden-test style task framing
+- directly supports comparing:
+  - native tools only
+  - native tools + `tldrf`
+
+Useful external references for later phases:
+
+- SWE-bench: https://github.com/SWE-bench/SWE-bench
+- RepoBench: https://github.com/Leolty/RepoBench
+- CodeEditorBench: https://github.com/DeepSoftwareAnalytics/CodeEditorBench
+- Debug-gym: https://github.com/microsoft/debug-gym
+- RefactorBench: https://refactorbench.github.io/
+
+Lower priority:
+
+- `ai-coding-lang-bench` is acceptable as a cheap model-capability smoke test, but it is not the right primary benchmark for `tldrf` because it is not centered on repository structure, retrieval policy, or deterministic graph-assisted workflows
+
+## Benchmark Arms
+
+Every agentic benchmark phase should compare at least these two arms:
+
+- Baseline arm:
+  - `rg`
+  - `grep`
+  - direct file reads
+  - tests
+- Augmented arm:
+  - same native tools
+  - plus `tldrf`
+  - plus the repo usage policy from [AGENTS.md](../AGENTS.md) and [docs/llm-tldr-reference-card.md](../docs/llm-tldr-reference-card.md)
+
+The augmented arm is not allowed to replace `rg` for exact lexical lookup.
+
+## Metrics That Matter
+
+Primary metrics:
+
+- solve rate
+- time to first passing test
+- wall-clock completion time
+- total input tokens
+- total output tokens
+- turn count
+- tool-call count
+- changed-file recall / precision
+- test-selection accuracy
+- tool-choice accuracy
+
+Secondary metrics:
+
+- judge score for open-ended explanations or plans
+- answer quality on structured Django packet tasks
+- localization accuracy
+- transcript length and context growth
+
+Judge policy:
+
+- use deterministic tests or scripted oracles wherever possible
+- use Claude Sonnet as judge only when deterministic scoring is not feasible
+
+## Phase Plan
+
+### Phase A: Reuse Existing `llm_ab` Harness
+
+Purpose:
+
+- cheaply test whether better `tldrf` context helps Kimi relative to `rg`-only context
+
+Work:
+
+- rerun existing Django structured and open-ended suites from:
+  - [benchmarks/llm/tasks.json](../benchmarks/llm/tasks.json)
+  - [benchmarks/llm/open_ended_tasks.json](../benchmarks/llm/open_ended_tasks.json)
+- run the same Kimi model in two conditions:
+  - baseline context arm built from native-tool packets
+  - augmented context arm built from `tldrf` packets
+- keep the judge fixed and stronger
+
+Acceptance:
+
+- we can quantify whether `tldrf`-over-`rg` uplift exists for Kimi before adding more models
+
+### Phase B: Tool-Usage Preflight and Tool-Choice Evaluation
+
+Purpose:
+
+- validate that the agent actually uses `tldrf` correctly before any expensive or large-scale benchmark run
+- test whether the agent uses the correct workflow before measuring patch success
+
+Gold policy source:
+
+- [AGENTS.md](../AGENTS.md)
+- [docs/llm-tldr-reference-card.md](../docs/llm-tldr-reference-card.md)
+
+Required preflight gate before full runs:
+
+- run a small live pilot on representative tasks before Phase C or later phases
+- record full transcripts plus per-step tool calls
+- manually review a small sample before trusting the aggregate score
+- if the agent skips `tldrf` on tasks where it should use it, or misuses it repeatedly, stop and tune the instruction surface before continuing
+- do not record or publish full Phase D / Phase E outcome numbers until this gate passes
+
+Initial pilot shape:
+
+- 8-12 representative tasks
+- at least 2 exact-lookup tasks where `rg-first` should win
+- at least 2 concept lookup tasks where `semantic/hybrid` should appear
+- at least 2 refactor tasks where `impact -> context -> rg` should appear
+- at least 2 debugging tasks where `slice -> dfg` should appear
+
+Initial labeled workflow classes:
+
+- exact symbol / definition -> `rg-first`
+- concept lookup -> `semantic/hybrid -> context`
+- refactor blast radius -> `impact -> context -> rg`
+- line-level debugging -> `slice -> dfg`
+- repeated queries -> daemon or MCP
+
+Metrics:
+
+- workflow-compliance rate
+- correct-first-tool rate
+- `tldrf`-usage rate on tasks where `tldrf` is expected
+- `rg-first` compliance on exact lexical tasks
+- tool-choice accuracy
+- unnecessary tool-call rate
+- dead-end-turn rate
+- recovery-after-wrong-first-tool rate
+- median turns before first appropriate tool use
+
+If the preflight gate fails, tune in this order:
+
+1. benchmark instructions / system prompt
+2. future `skill.md` or `AGENTS.md` guidance
+3. task examples / few-shot demonstrations
+4. tool wrappers or clearer tool descriptions if the model is still confused
+
+Failed preflight runs are invalidation signals, not product evidence:
+
+- they mean the instruction surface or tool ergonomics are not ready
+- they should trigger tuning and rerun, not be counted as wins/losses for `tldrf`
+
+Provisional preflight acceptance gate:
+
+- correct-first-tool rate >= 0.80
+- workflow-compliance rate >= 0.80
+- `tldrf`-usage rate >= 0.90 on `tldrf`-required tasks
+- `rg-first` compliance >= 0.90 on exact-lookup tasks
+- median dead-end turns <= 1
+- manual transcript review confirms no obvious repeated failure mode
+
+Acceptance:
+
+- tool policy is stable enough that benchmark noise is not dominated by bad workflow selection
+- instruction tuning happens before, not after, the first expensive full run
+- failed preflight traces are excluded from benchmark result summaries
+
+### Phase C: Deterministic Task Families That Reflect TLDRF Strengths
+
+Purpose:
+
+- prove where `tldrf` helps and where it should not be used
+
+Priority task families:
+
+- concept lookup when the symbol name is unknown
+- impact-aware refactor planning
+- line-level debugging and value provenance
+- affected-test selection
+- compound "find code and who calls it"
+- exact identifier lookup tasks where `rg` should win
+
+Corpora:
+
+- start with Django
+- then add `requests`
+- then add `urllib3`
+
+Acceptance:
+
+- task categories clearly separate:
+  - `rg`-wins tasks
+  - `tldrf`-wins tasks
+  - mixed-policy tasks where the combo is strongest
+
+### Phase D: Local End-to-End Patch/Test Tasks
+
+Purpose:
+
+- measure the real edit loop instead of only answer quality
+
+Task shape:
+
+- debugging fixes
+- small refactors with blast radius
+- multi-file change-impact tasks
+- tests that should be selected or updated
+
+Scoring:
+
+- hidden tests or scripted oracles first
+- judge only for non-deterministic outputs like explanations or refactor plans
+
+Acceptance:
+
+- augmented arm shows better solve rate, or equal solve rate with materially lower time/tokens/turns
+
+### Phase E: SWE-bench Verified Pilot
+
+Purpose:
+
+- validate the local findings on a recognized external benchmark
+
+Initial run:
+
+- 20-50 Django-heavy SWE-bench Verified tasks
+- baseline arm vs augmented arm
+- Kimi as the answer model
+- Claude Sonnet as the judge only where a secondary qualitative read is useful
+
+Record:
+
+- success rate
+- turns
+- tokens
+- time
+- patch quality notes
+
+Acceptance:
+
+- the pilot is strong enough to justify scale-out
+
+### Phase F: External Scale-Out
+
+Purpose:
+
+- turn the pilot into a credible public result
+
+Run:
+
+- 200+ SWE-bench Verified tasks if pilot signal is positive
+- optional follow-up on full SWE-bench
+- optional later validation on RepoBench / RefactorBench / Debug-gym depending on where the local signal is strongest
+
+Acceptance:
+
+- a stable result that answers whether Kimi with `tldrf` is meaningfully better than Kimi without it
+
+### Phase G: Optional Model-Matrix Expansion
+
+Purpose:
+
+- rerun the now-stable benchmark with additional answer models after the Kimi baseline is proven
+
+Possible follow-ups:
+
+- DeepSeek as a cheaper comparison model
+- one stronger already-supported model in the current harness
+- future Kimi revisions
+
+Acceptance:
+
+- model-to-model comparisons are built on top of a stable same-model baseline rather than mixed into the first benchmark pass
+
+## Implementation Work Needed In This Repo
+
+Likely files to change:
+
+- [scripts/bench_llm_ab_run.py](../scripts/bench_llm_ab_run.py)
+  - add OpenRouter / OpenAI-compatible provider adapter
+  - extend full-run usage accounting
+- New: `scripts/bench_tool_choice.py`
+  - add a preflight mode that emits transcript-level workflow-compliance reports
+  - evaluate workflow selection quality
+- New: `scripts/bench_agent_tasks.py`
+  - run end-to-end tool-using tasks
+- New: `benchmarks/agentic/preflight_tasks.json`
+- New: `benchmarks/agentic/tool_choice_tasks.json`
+- New: `benchmarks/agentic/patch_tasks.json`
+- New: `benchmarks/agentic/swebench_subset.json`
+- [benchmarks/README.md](../benchmarks/README.md)
+  - publish the new benchmark family and results
+
+## Immediate Next Steps
+
+1. Create the OpenRouter provider adapter so Kimi can run inside the existing answer-model harness.
+2. Reuse the current Django `llm_ab` packets and run the smallest possible pilot:
+   - Kimi baseline arm
+   - Kimi plus `tldrf` arm
+3. Define the preflight tool-usage suite and transcript review gate from `AGENTS.md` and the reference card.
+4. Run the preflight gate and tune the instruction surface until workflow compliance is acceptable.
+5. Define the full tool-choice gold policy suite.
+6. Curate a first batch of local patch/test tasks on Django.
+7. Select the first 20-50 Django-heavy SWE-bench Verified tasks for the external pilot.
+
+## Running Log
+
+- 2026-03-06: Created this plan to combine the existing local benchmark stack with a new agentic evaluation goal focused on Kimi-with-`tldrf` vs Kimi-without-`tldrf`.
+- 2026-03-06: Locked the preferred initial model stack as:
+  - answer model: Kimi on OpenRouter
+  - fallback cheap answer model: DeepSeek on OpenRouter
+  - judge: Claude Sonnet
+- 2026-03-06: Narrowed the first benchmark pass to a same-model comparison only:
+  - Kimi with native tools
+  - Kimi with native tools plus `tldrf`
+- 2026-03-06: Deferred cross-model comparisons until after the first same-model baseline is working and trusted.
+- 2026-03-06: Locked SWE-bench Verified as the preferred first external validation source, but only after local harness reuse and tool-choice validation.
+- 2026-03-06: Added an explicit preflight gate before full agentic runs:
+  - small live task set
+  - transcript review
+  - workflow-compliance metrics
+  - instruction tuning if the agent does not use `tldrf` appropriately
+
+## Gotchas / Learnings
+
+- Existing `llm_ab` results are valuable, but they measure prebuilt context packets, not tool-using agents.
+- A strong external benchmark does not remove the need for a local benchmark. Local suites are still the fastest way to tune tool policy, packing, and harness behavior.
+- If the model does not know when to use `tldrf`, the benchmark mostly measures prompt quality, not tool utility. Full runs should be blocked until the preflight gate passes.
+- The most realistic winning setup is expected to be policy-combined, not tool-exclusive:
+  - `rg` for exact lookup
+  - `tldrf` for structure and concept search
+- Cost claims must be treated as variable until provider pricing is rechecked at execution time.

--- a/scripts/bench_compound_semantic_impact.py
+++ b/scripts/bench_compound_semantic_impact.py
@@ -17,6 +17,9 @@ from bench_util import (
     get_repo_root,
     make_report,
     now_utc_compact,
+    query_daemon_ok,
+    restart_benchmark_daemon,
+    stop_benchmark_daemon,
     write_report,
 )
 from tldr.indexing.index import get_index_context
@@ -114,8 +117,37 @@ def _jaccard(a: set[tuple[str, str]], b: set[tuple[str, str]]) -> float:
     return len(a & b) / len(a | b)
 
 
+def _impact_payload_from_daemon_response(response: dict[str, Any]) -> dict[str, Any] | None:
+    payload = response.get("result")
+    if isinstance(payload, dict):
+        return payload
+
+    callers = response.get("callers")
+    if not isinstance(callers, list):
+        return None
+
+    normalized_callers: list[dict[str, Any]] = []
+    for item in callers:
+        if not isinstance(item, dict):
+            continue
+        file_path = item.get("file")
+        function = item.get("caller")
+        if not isinstance(file_path, str) or not isinstance(function, str):
+            continue
+        normalized_callers.append(
+            {
+                "file": file_path,
+                "function": function,
+                "line": item.get("line") if isinstance(item.get("line"), int) else None,
+            }
+        )
+    return {"targets": {"legacy": {"callers": normalized_callers}}}
+
+
 def _sequential_baseline(
+    repo_root: Path,
     *,
+    index_ctx: Any,
     project_path: str,
     query: str,
     k: int,
@@ -140,33 +172,60 @@ def _sequential_baseline(
     impact_language: str,
     ignore_spec,
     workspace_root,
+    use_daemon: bool = False,
 ) -> dict[str, Any]:
     from tldr.analysis import impact_analysis
     from tldr.cross_file_calls import ProjectCallGraph, build_project_call_graph
 
     total_start = time.perf_counter()
     semantic_start = time.perf_counter()
-    semantic_rows = semantic_search(
-        project_path,
-        query,
-        k=k,
-        model=model,
-        device=device,
-        index_paths=index_paths,
-        index_config=index_config,
-        retrieval_mode=retrieval_mode,
-        no_result_guard=no_result_guard,
-        rg_pattern=rg_pattern,
-        rg_glob=rg_glob,
-        rrf_k=rrf_k,
-        abstain_threshold=abstain_threshold,
-        abstain_empty=abstain_empty,
-        rerank=rerank,
-        rerank_top_n=rerank_top_n,
-        max_latency_ms_p50_ratio=max_latency_ms_p50_ratio,
-        max_payload_tokens_median_ratio=max_payload_tokens_median_ratio,
-        budget_tokens=budget_tokens,
-    )
+    if use_daemon:
+        semantic_res = query_daemon_ok(
+            repo_root,
+            index_ctx=index_ctx,
+            command={
+                "cmd": "semantic",
+                "action": "search",
+                "query": query,
+                "k": int(k),
+                "model": model,
+                "retrieval_mode": retrieval_mode,
+                "no_result_guard": no_result_guard,
+                "rg_pattern": rg_pattern,
+                "rg_glob": rg_glob,
+                "rrf_k": int(rrf_k),
+                "abstain_threshold": abstain_threshold,
+                "abstain_empty": bool(abstain_empty),
+                "rerank": bool(rerank),
+                "rerank_top_n": int(rerank_top_n),
+                "max_latency_ms_p50_ratio": max_latency_ms_p50_ratio,
+                "max_payload_tokens_median_ratio": max_payload_tokens_median_ratio,
+                "budget_tokens": budget_tokens,
+            },
+        )
+        semantic_rows = semantic_res.get("results") or semantic_res.get("result") or []
+    else:
+        semantic_rows = semantic_search(
+            project_path,
+            query,
+            k=k,
+            model=model,
+            device=device,
+            index_paths=index_paths,
+            index_config=index_config,
+            retrieval_mode=retrieval_mode,
+            no_result_guard=no_result_guard,
+            rg_pattern=rg_pattern,
+            rg_glob=rg_glob,
+            rrf_k=rrf_k,
+            abstain_threshold=abstain_threshold,
+            abstain_empty=abstain_empty,
+            rerank=rerank,
+            rerank_top_n=rerank_top_n,
+            max_latency_ms_p50_ratio=max_latency_ms_p50_ratio,
+            max_payload_tokens_median_ratio=max_payload_tokens_median_ratio,
+            budget_tokens=budget_tokens,
+        )
     semantic_ms = (time.perf_counter() - semantic_start) * 1000.0
 
     normalized_rows = [dict(row) for row in semantic_rows if isinstance(row, dict)]
@@ -198,29 +257,29 @@ def _sequential_baseline(
             "impact_attempted": 0,
         }
 
-    languages = _lane4_languages_from_semantic_rows(
-        normalized_rows,
-        impact_language=impact_language,
-    )
-
     combined_graph = ProjectCallGraph()
     partial_failures = len(selection_failures)
-    if languages:
-        for language in languages:
-            try:
-                graph = build_project_call_graph(
-                    project_path,
-                    language=language,
-                    ignore_spec=ignore_spec,
-                    workspace_root=workspace_root,
-                )
-            except Exception:
-                partial_failures += 1
-                continue
-            for edge in graph.sorted_edges():
-                combined_graph.add_edge(*edge)
-    else:
-        partial_failures += len(targets)
+    if not use_daemon:
+        languages = _lane4_languages_from_semantic_rows(
+            normalized_rows,
+            impact_language=impact_language,
+        )
+        if languages:
+            for language in languages:
+                try:
+                    graph = build_project_call_graph(
+                        project_path,
+                        language=language,
+                        ignore_spec=ignore_spec,
+                        workspace_root=workspace_root,
+                    )
+                except Exception:
+                    partial_failures += 1
+                    continue
+                for edge in graph.sorted_edges():
+                    combined_graph.add_edge(*edge)
+        else:
+            partial_failures += len(targets)
 
     impact_rows: list[dict[str, Any]] = []
     impact_latencies: list[float] = []
@@ -231,6 +290,26 @@ def _sequential_baseline(
         start = time.perf_counter()
         payload = None
         for alias in aliases:
+            if use_daemon:
+                try:
+                    response = query_daemon_ok(
+                        repo_root,
+                        index_ctx=index_ctx,
+                        command={
+                            "cmd": "impact",
+                            "func": alias,
+                            "depth": int(impact_depth),
+                            **({"file": file_path} if isinstance(file_path, str) and file_path else {}),
+                        },
+                    )
+                except Exception:
+                    continue
+                candidate = _impact_payload_from_daemon_response(response)
+                if isinstance(candidate, dict) and candidate.get("error"):
+                    continue
+                payload = candidate
+                break
+
             if not combined_graph.edges:
                 continue
             candidate = impact_analysis(
@@ -323,6 +402,11 @@ def main() -> int:
     ap.add_argument("--lane2-rerank-top-n", type=int, default=8)
     ap.add_argument("--lane2-max-latency-ms-p50-ratio", type=float, default=1.10)
     ap.add_argument("--lane2-max-payload-tokens-median-ratio", type=float, default=0.90)
+    ap.add_argument(
+        "--use-daemon",
+        action="store_true",
+        help="Route semantic and impact queries through the daemon instead of in-process API calls.",
+    )
     ap.add_argument("--out", default=None)
     args = ap.parse_args()
 
@@ -356,6 +440,18 @@ def main() -> int:
     if not index_ctx.paths.semantic_faiss.exists() or not index_ctx.paths.semantic_metadata.exists():
         raise SystemExit("error: semantic index artifacts missing")
 
+    semantic_meta: dict[str, Any] = {}
+    try:
+        semantic_meta = json.loads(index_ctx.paths.semantic_metadata.read_text())
+    except Exception:
+        semantic_meta = {}
+
+    daemon_ready: dict[str, Any] | None = None
+    if args.use_daemon:
+        daemon_ready = restart_benchmark_daemon(corpus_root, index_ctx=index_ctx)
+        if not daemon_ready.get("ok"):
+            raise SystemExit(f"error: daemon did not become ready: {daemon_ready}")
+
     compound_tte_ms: list[float] = []
     sequential_tte_ms: list[float] = []
     compound_payload: list[float] = []
@@ -368,148 +464,183 @@ def main() -> int:
 
     per_query: list[dict[str, Any]] = []
 
-    for trial in range(1, int(args.trials) + 1):
-        for query_spec in queries:
-            compound_start = time.perf_counter()
-            compound = compound_semantic_impact_search(
-                str(corpus_root),
-                query_spec.query,
-                k=int(args.k),
-                index_paths=index_ctx.paths,
-                index_config=index_ctx.config,
-                retrieval_mode=str(args.retrieval_mode),
-                no_result_guard=str(args.no_result_guard),
-                rg_pattern=query_spec.rg_pattern,
-                rg_glob="*.py",
-                abstain_threshold=args.lane2_abstain_threshold,
-                abstain_empty=bool(args.lane2_abstain_empty),
-                rerank=bool(args.lane2_rerank),
-                rerank_top_n=int(args.lane2_rerank_top_n),
-                max_latency_ms_p50_ratio=args.lane2_max_latency_ms_p50_ratio,
-                max_payload_tokens_median_ratio=args.lane2_max_payload_tokens_median_ratio,
-                budget_tokens=args.budget_tokens,
-                impact_depth=int(args.impact_depth),
-                impact_limit=int(args.impact_limit),
-                impact_language=str(args.impact_language),
-                ignore_spec=None,
-                workspace_root=None,
-            )
-            compound_elapsed_ms = (time.perf_counter() - compound_start) * 1000.0
+    try:
+        for trial in range(1, int(args.trials) + 1):
+            for query_spec in queries:
+                compound_start = time.perf_counter()
+                if args.use_daemon:
+                    compound_res = query_daemon_ok(
+                        corpus_root,
+                        index_ctx=index_ctx,
+                        command={
+                            "cmd": "semantic",
+                            "action": "search",
+                            "query": query_spec.query,
+                            "k": int(args.k),
+                            "retrieval_mode": str(args.retrieval_mode),
+                            "no_result_guard": str(args.no_result_guard),
+                            "rg_pattern": query_spec.rg_pattern,
+                            "rg_glob": "*.py",
+                            "compound_impact": True,
+                            "impact_depth": int(args.impact_depth),
+                            "impact_limit": int(args.impact_limit),
+                            "impact_language": str(args.impact_language),
+                            "abstain_threshold": args.lane2_abstain_threshold,
+                            "abstain_empty": bool(args.lane2_abstain_empty),
+                            "rerank": bool(args.lane2_rerank),
+                            "rerank_top_n": int(args.lane2_rerank_top_n),
+                            "max_latency_ms_p50_ratio": args.lane2_max_latency_ms_p50_ratio,
+                            "max_payload_tokens_median_ratio": args.lane2_max_payload_tokens_median_ratio,
+                            "budget_tokens": args.budget_tokens,
+                        },
+                    )
+                    compound = compound_res.get("result") or compound_res.get("results") or {}
+                else:
+                    compound = compound_semantic_impact_search(
+                        str(corpus_root),
+                        query_spec.query,
+                        k=int(args.k),
+                        index_paths=index_ctx.paths,
+                        index_config=index_ctx.config,
+                        retrieval_mode=str(args.retrieval_mode),
+                        no_result_guard=str(args.no_result_guard),
+                        rg_pattern=query_spec.rg_pattern,
+                        rg_glob="*.py",
+                        abstain_threshold=args.lane2_abstain_threshold,
+                        abstain_empty=bool(args.lane2_abstain_empty),
+                        rerank=bool(args.lane2_rerank),
+                        rerank_top_n=int(args.lane2_rerank_top_n),
+                        max_latency_ms_p50_ratio=args.lane2_max_latency_ms_p50_ratio,
+                        max_payload_tokens_median_ratio=args.lane2_max_payload_tokens_median_ratio,
+                        budget_tokens=args.budget_tokens,
+                        impact_depth=int(args.impact_depth),
+                        impact_limit=int(args.impact_limit),
+                        impact_language=str(args.impact_language),
+                        ignore_spec=None,
+                        workspace_root=None,
+                    )
+                compound_elapsed_ms = (time.perf_counter() - compound_start) * 1000.0
 
-            sequential = _sequential_baseline(
-                project_path=str(corpus_root),
-                query=query_spec.query,
-                k=int(args.k),
-                model=None,
-                device=None,
-                index_paths=index_ctx.paths,
-                index_config=index_ctx.config,
-                retrieval_mode=str(args.retrieval_mode),
-                no_result_guard=str(args.no_result_guard),
-                rg_pattern=query_spec.rg_pattern,
-                rg_glob="*.py",
-                rrf_k=60,
-                abstain_threshold=args.lane2_abstain_threshold,
-                abstain_empty=bool(args.lane2_abstain_empty),
-                rerank=bool(args.lane2_rerank),
-                rerank_top_n=int(args.lane2_rerank_top_n),
-                max_latency_ms_p50_ratio=args.lane2_max_latency_ms_p50_ratio,
-                max_payload_tokens_median_ratio=args.lane2_max_payload_tokens_median_ratio,
-                budget_tokens=args.budget_tokens,
-                impact_depth=int(args.impact_depth),
-                impact_limit=int(args.impact_limit),
-                impact_language=str(args.impact_language),
-                ignore_spec=None,
-                workspace_root=None,
-            )
+                sequential = _sequential_baseline(
+                    corpus_root,
+                    index_ctx=index_ctx,
+                    project_path=str(corpus_root),
+                    query=query_spec.query,
+                    k=int(args.k),
+                    model=None,
+                    device=None,
+                    index_paths=index_ctx.paths,
+                    index_config=index_ctx.config,
+                    retrieval_mode=str(args.retrieval_mode),
+                    no_result_guard=str(args.no_result_guard),
+                    rg_pattern=query_spec.rg_pattern,
+                    rg_glob="*.py",
+                    rrf_k=60,
+                    abstain_threshold=args.lane2_abstain_threshold,
+                    abstain_empty=bool(args.lane2_abstain_empty),
+                    rerank=bool(args.lane2_rerank),
+                    rerank_top_n=int(args.lane2_rerank_top_n),
+                    max_latency_ms_p50_ratio=args.lane2_max_latency_ms_p50_ratio,
+                    max_payload_tokens_median_ratio=args.lane2_max_payload_tokens_median_ratio,
+                    budget_tokens=args.budget_tokens,
+                    impact_depth=int(args.impact_depth),
+                    impact_limit=int(args.impact_limit),
+                    impact_language=str(args.impact_language),
+                    ignore_spec=None,
+                    workspace_root=None,
+                    use_daemon=bool(args.use_daemon),
+                )
 
-            compound_retrieval = [
-                row.get("file")
-                for row in compound.get("results", [])
-                if isinstance(row, dict) and isinstance(row.get("file"), str)
-            ]
-            sequential_retrieval = [
-                path for path in sequential.get("retrieval_ranked_files", []) if isinstance(path, str)
-            ]
+                compound_retrieval = [
+                    row.get("file")
+                    for row in compound.get("results", [])
+                    if isinstance(row, dict) and isinstance(row.get("file"), str)
+                ]
+                sequential_retrieval = [
+                    path for path in sequential.get("retrieval_ranked_files", []) if isinstance(path, str)
+                ]
 
-            top_k = int(args.k)
-            set_compound = set(compound_retrieval[:top_k])
-            set_sequential = set(sequential_retrieval[:top_k])
-            overlap = 1.0 if not set_compound and not set_sequential else (
-                len(set_compound & set_sequential) / max(1, len(set_compound | set_sequential))
-            )
-            overlap_scores.append(float(overlap))
+                top_k = int(args.k)
+                set_compound = set(compound_retrieval[:top_k])
+                set_sequential = set(sequential_retrieval[:top_k])
+                overlap = 1.0 if not set_compound and not set_sequential else (
+                    len(set_compound & set_sequential) / max(1, len(set_compound | set_sequential))
+                )
+                overlap_scores.append(float(overlap))
 
-            comp_rows = {
-                int(row.get("rank")): row
-                for row in compound.get("results", [])
-                if isinstance(row, dict) and isinstance(row.get("rank"), int)
-            }
-            seq_rows = {
-                int(row.get("rank")): row
-                for row in sequential.get("impact_rows", [])
-                if isinstance(row, dict) and isinstance(row.get("rank"), int)
-            }
-            jaccards: list[float] = []
-            for rank in sorted(set(comp_rows) & set(seq_rows)):
-                comp_callers = _extract_caller_set(comp_rows[rank])
-                seq_callers = _extract_caller_set(seq_rows[rank])
-                jaccards.append(_jaccard(comp_callers, seq_callers))
-            impact_jaccard = float(statistics.mean(jaccards)) if jaccards else 1.0
-            jaccard_scores.append(impact_jaccard)
-
-            compound_tte = _safe_float(compound.get("timing_ms", {}).get("total"))
-            if compound_tte is None:
-                compound_tte = float(compound_elapsed_ms)
-            sequential_tte = _safe_float(sequential.get("time_to_evidence_ms")) or 0.0
-            compound_tte_ms.append(float(compound_tte))
-            sequential_tte_ms.append(float(sequential_tte))
-            if compound_tte <= sequential_tte:
-                compound_win_count += 1
-
-            compound_payload_tokens = _safe_float(
-                compound.get("regression_metadata", {}).get("payload_tokens_median")
-            ) or 0.0
-            sequential_payload_tokens = _safe_float(sequential.get("payload_tokens")) or 0.0
-            compound_payload.append(float(compound_payload_tokens))
-            sequential_payload.append(float(sequential_payload_tokens))
-
-            if str(compound.get("status")) != "ok":
-                compound_partial += 1
-            if str(sequential.get("status")) != "ok":
-                sequential_partial += 1
-
-            per_query.append(
-                {
-                    "query_id": query_spec.query_id,
-                    "trial": int(trial),
-                    "budget_tokens": int(args.budget_tokens),
-                    "compound": {
-                        "status": str(compound.get("status")),
-                        "time_to_evidence_ms": float(compound_tte),
-                        "semantic_ms": float(compound.get("timing_ms", {}).get("semantic", 0.0)),
-                        "impact_ms_total": float(compound.get("timing_ms", {}).get("impact_total", 0.0)),
-                        "payload_tokens": float(compound_payload_tokens),
-                        "partial_failures_count": int(len(compound.get("partial_failures", []))),
-                    },
-                    "sequential": {
-                        "status": str(sequential.get("status")),
-                        "time_to_evidence_ms": float(sequential_tte),
-                        "semantic_ms": float(sequential.get("semantic_ms", 0.0)),
-                        "impact_ms_total": float(sequential.get("impact_ms_total", 0.0)),
-                        "payload_tokens": float(sequential_payload_tokens),
-                        "partial_failures_count": int(sequential.get("partial_failures_count", 0)),
-                    },
-                    "delta": {
-                        "tte_ms": float(compound_tte - sequential_tte),
-                        "payload_tokens": float(compound_payload_tokens - sequential_payload_tokens),
-                    },
-                    "quality": {
-                        "retrieval_overlap_at_k": float(overlap),
-                        "impact_callers_jaccard": float(impact_jaccard),
-                    },
+                comp_rows = {
+                    int(row.get("rank")): row
+                    for row in compound.get("results", [])
+                    if isinstance(row, dict) and isinstance(row.get("rank"), int)
                 }
-            )
+                seq_rows = {
+                    int(row.get("rank")): row
+                    for row in sequential.get("impact_rows", [])
+                    if isinstance(row, dict) and isinstance(row.get("rank"), int)
+                }
+                jaccards: list[float] = []
+                for rank in sorted(set(comp_rows) & set(seq_rows)):
+                    comp_callers = _extract_caller_set(comp_rows[rank])
+                    seq_callers = _extract_caller_set(seq_rows[rank])
+                    jaccards.append(_jaccard(comp_callers, seq_callers))
+                impact_jaccard = float(statistics.mean(jaccards)) if jaccards else 1.0
+                jaccard_scores.append(impact_jaccard)
+
+                compound_tte = _safe_float(compound.get("timing_ms", {}).get("total"))
+                if compound_tte is None:
+                    compound_tte = float(compound_elapsed_ms)
+                sequential_tte = _safe_float(sequential.get("time_to_evidence_ms")) or 0.0
+                compound_tte_ms.append(float(compound_tte))
+                sequential_tte_ms.append(float(sequential_tte))
+                if compound_tte <= sequential_tte:
+                    compound_win_count += 1
+
+                compound_payload_tokens = _safe_float(
+                    compound.get("regression_metadata", {}).get("payload_tokens_median")
+                ) or 0.0
+                sequential_payload_tokens = _safe_float(sequential.get("payload_tokens")) or 0.0
+                compound_payload.append(float(compound_payload_tokens))
+                sequential_payload.append(float(sequential_payload_tokens))
+
+                if str(compound.get("status")) != "ok":
+                    compound_partial += 1
+                if str(sequential.get("status")) != "ok":
+                    sequential_partial += 1
+
+                per_query.append(
+                    {
+                        "query_id": query_spec.query_id,
+                        "trial": int(trial),
+                        "budget_tokens": int(args.budget_tokens),
+                        "compound": {
+                            "status": str(compound.get("status")),
+                            "time_to_evidence_ms": float(compound_tte),
+                            "semantic_ms": float(compound.get("timing_ms", {}).get("semantic", 0.0)),
+                            "impact_ms_total": float(compound.get("timing_ms", {}).get("impact_total", 0.0)),
+                            "payload_tokens": float(compound_payload_tokens),
+                            "partial_failures_count": int(len(compound.get("partial_failures", []))),
+                        },
+                        "sequential": {
+                            "status": str(sequential.get("status")),
+                            "time_to_evidence_ms": float(sequential_tte),
+                            "semantic_ms": float(sequential.get("semantic_ms", 0.0)),
+                            "impact_ms_total": float(sequential.get("impact_ms_total", 0.0)),
+                            "payload_tokens": float(sequential_payload_tokens),
+                            "partial_failures_count": int(sequential.get("partial_failures_count", 0)),
+                        },
+                        "delta": {
+                            "tte_ms": float(compound_tte - sequential_tte),
+                            "payload_tokens": float(compound_payload_tokens - sequential_payload_tokens),
+                        },
+                        "quality": {
+                            "retrieval_overlap_at_k": float(overlap),
+                            "impact_callers_jaccard": float(impact_jaccard),
+                        },
+                    }
+                )
+    finally:
+        if args.use_daemon:
+            stop_benchmark_daemon(corpus_root, index_ctx=index_ctx)
 
     compound_stats = _summary(compound_tte_ms)
     sequential_stats = _summary(sequential_tte_ms)
@@ -523,6 +654,10 @@ def main() -> int:
         protocol={
             "schema_version": SCHEMA_VERSION,
             "feature_set_id": "feature.compound-semantic-impact.v1",
+            "cache_root": str(index_ctx.cache_root) if index_ctx.cache_root is not None else None,
+            "index_id": index_ctx.index_id,
+            "semantic_model": semantic_meta.get("model") if isinstance(semantic_meta, dict) else None,
+            "semantic_dimension": semantic_meta.get("dimension") if isinstance(semantic_meta, dict) else None,
             "queries": str(Path(args.queries).resolve()),
             "query_limit": int(args.query_limit),
             "budget_tokens": int(args.budget_tokens),
@@ -532,6 +667,8 @@ def main() -> int:
             "impact_depth": int(args.impact_depth),
             "impact_limit": int(args.impact_limit),
             "impact_language": str(args.impact_language),
+            "use_daemon": bool(args.use_daemon),
+            "daemon_ready": daemon_ready,
             "sequential_baseline_definition": "semantic_search + bounded per-row impact_analysis",
             "compound_command_template": (
                 "uv run tldrf semantic search \"{query}\" --path {repo_root} --k {k} --lang python "

--- a/scripts/bench_perf_daemon_vs_cli.py
+++ b/scripts/bench_perf_daemon_vs_cli.py
@@ -7,9 +7,7 @@ import statistics
 import subprocess
 import sys
 import time
-from contextlib import redirect_stderr, redirect_stdout
 from dataclasses import dataclass
-from io import StringIO
 from pathlib import Path
 from typing import Any
 
@@ -22,10 +20,12 @@ from bench_util import (
     make_report,
     now_utc_compact,
     percentiles,
+    restart_benchmark_daemon,
+    stop_benchmark_daemon,
     write_report,
 )
 
-from tldr.daemon.startup import query_daemon, start_daemon, stop_daemon
+from tldr.daemon.startup import query_daemon
 from tldr.indexing.index import IndexContext, get_index_context
 from tldr.indexing.management import get_index_info, list_indexes
 
@@ -381,6 +381,13 @@ def _build_command_set(
     return cmds, protocol_details
 
 
+def _parse_requested_commands(raw: str | None) -> set[str] | None:
+    if raw is None:
+        return None
+    names = {part.strip() for part in str(raw).split(",") if part.strip()}
+    return names or None
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description="Phase 3 perf microbench: daemon vs CLI latency for key commands.")
     group = ap.add_mutually_exclusive_group(required=True)
@@ -407,8 +414,20 @@ def main() -> int:
         action="store_true",
         help="Also benchmark `semantic search` (only runs if semantic index artifacts exist).",
     )
+    ap.add_argument(
+        "--commands",
+        default=None,
+        help=(
+            "Optional comma-separated command filter (for example: "
+            "semantic_search,search,impact). Default benchmarks every applicable command."
+        ),
+    )
     ap.add_argument("--out", default=None, help="Write JSON report to this path (default under benchmark/runs/).")
     args = ap.parse_args()
+
+    requested_commands = _parse_requested_commands(args.commands)
+    if requested_commands and "semantic_search" in requested_commands and not args.include_semantic:
+        raise SystemExit("error: --commands semantic_search requires --include-semantic")
 
     tldr_repo_root = get_repo_root()
     corpus_id = args.corpus
@@ -445,12 +464,9 @@ def main() -> int:
         allow_create=True,
     )
 
-    # Start daemon and make sure a call graph cache exists so impact/context are "warm".
-    with redirect_stdout(StringIO()), redirect_stderr(StringIO()):
-        stop_daemon(repo_root, index_ctx=index_ctx)
-        start_daemon(repo_root, foreground=False, index_ctx=index_ctx)
-
-    daemon_ready = _wait_for_daemon_ready(repo_root, index_ctx=index_ctx)
+    daemon_ready = restart_benchmark_daemon(repo_root, index_ctx=index_ctx)
+    if not daemon_ready.get("ok"):
+        raise SystemExit(f"error: daemon did not become ready: {daemon_ready}")
     warm_info = _maybe_warm_call_graph(repo_root, index_ctx=index_ctx, language=str(args.lang))
 
     cmds, protocol_details = _build_command_set(
@@ -473,6 +489,11 @@ def main() -> int:
             and index_paths.semantic_metadata.exists()
         )
         if semantic_ok:
+            semantic_meta: dict[str, Any] = {}
+            try:
+                semantic_meta = json.loads(index_paths.semantic_metadata.read_text())
+            except Exception:
+                semantic_meta = {}
             leaf = (target.symbol if target else "entry").split(".")[-1]
             query = f"{leaf} implementation"
             cmds.append(
@@ -485,10 +506,22 @@ def main() -> int:
             )
             semantic_status["ok"] = True
             semantic_status["query"] = query
+            semantic_status["model"] = semantic_meta.get("model") if isinstance(semantic_meta, dict) else None
+            semantic_status["dimension"] = semantic_meta.get("dimension") if isinstance(semantic_meta, dict) else None
         else:
             semantic_status["ok"] = False
             semantic_status["skipped"] = True
             semantic_status["reason"] = "semantic index artifacts missing (run `tldrf semantic index` first)"
+
+    if requested_commands:
+        available = {c.name for c in cmds}
+        missing = sorted(requested_commands - available)
+        if missing:
+            raise SystemExit(
+                "error: requested commands unavailable for this run: " + ", ".join(missing)
+            )
+        cmds = [c for c in cmds if c.name in requested_commands]
+    protocol_details["commands"] = [c.name for c in cmds]
 
     results: list[dict[str, Any]] = []
     for c in cmds:
@@ -517,9 +550,7 @@ def main() -> int:
             }
         )
 
-    # Stop daemon to avoid side effects for other work.
-    with redirect_stdout(StringIO()), redirect_stderr(StringIO()):
-        stop_daemon(repo_root, index_ctx=index_ctx)
+    stop_benchmark_daemon(repo_root, index_ctx=index_ctx)
 
     # Cache sizing / index artifacts (via the same JSON contract as `tldrf index list/info`).
     cache_root_path = index_ctx.cache_root

--- a/scripts/bench_retrieval_quality.py
+++ b/scripts/bench_retrieval_quality.py
@@ -19,6 +19,9 @@ from bench_util import (
     get_repo_root,
     make_report,
     now_utc_compact,
+    query_daemon_ok,
+    restart_benchmark_daemon,
+    stop_benchmark_daemon,
     write_report,
 )
 
@@ -104,6 +107,7 @@ def _semantic_rank_files(
     index_ctx: IndexContext,
     query: str,
     k: int,
+    use_daemon: bool = False,
 ) -> list[str] | None:
     paths = index_ctx.paths
     cfg = index_ctx.config
@@ -112,15 +116,28 @@ def _semantic_rank_files(
     if not (paths.semantic_faiss.exists() and paths.semantic_metadata.exists()):
         return None
 
-    from tldr.semantic import semantic_search
+    if use_daemon:
+        res = query_daemon_ok(
+            repo_root,
+            index_ctx=index_ctx,
+            command={
+                "cmd": "semantic",
+                "action": "search",
+                "query": query,
+                "k": int(k),
+            },
+        )
+        results = res.get("results") or res.get("result") or []
+    else:
+        from tldr.semantic import semantic_search
 
-    results = semantic_search(
-        str(repo_root),
-        query,
-        k=int(k),
-        index_paths=paths,
-        index_config=cfg,
-    )
+        results = semantic_search(
+            str(repo_root),
+            query,
+            k=int(k),
+            index_paths=paths,
+            index_config=cfg,
+        )
 
     ranked: list[str] = []
     for r in results or []:
@@ -205,6 +222,26 @@ def _effective_k_from_budget_tokens(k: int, *, budget_tokens: Any) -> int:
     return int(_semantic_effective_k(k, budget_tokens=budget_tokens))
 
 
+def _record_ranking(
+    ranking: list[str],
+    *,
+    relevant: set[str],
+    ks: list[int],
+    max_k: int,
+) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "mrr": _mrr(ranking, relevant) if relevant else None,
+        "top_files": ranking[:max_k],
+    }
+    for k in ks:
+        if relevant:
+            out[f"recall@{k}"] = _recall_at_k(ranking, relevant, k)
+            out[f"precision@{k}"] = _precision_at_k(ranking, relevant, k)
+        else:
+            out[f"fpr@{k}"] = _fpr_at_k(ranking, k=k)
+    return out
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description="Phase 5 retrieval-quality benchmarks (rg vs semantic vs hybrid).")
     group = ap.add_mutually_exclusive_group(required=True)
@@ -247,6 +284,11 @@ def main() -> int:
         type=int,
         default=None,
         help="Optional lane3 budget-aware retrieval control (reference budget: 2000).",
+    )
+    ap.add_argument(
+        "--use-daemon",
+        action="store_true",
+        help="Route semantic queries through the daemon instead of in-process API calls.",
     )
     ap.add_argument("--out", default=None, help="Write JSON report to this path (default under benchmark/runs/).")
     args = ap.parse_args()
@@ -328,115 +370,143 @@ def main() -> int:
             semantic_meta = json.loads(index_ctx.paths.semantic_metadata.read_text())
         except (OSError, json.JSONDecodeError):
             semantic_meta = None
+    daemon_ready: dict[str, Any] | None = None
+    if args.use_daemon:
+        daemon_ready = restart_benchmark_daemon(repo_root, index_ctx=index_ctx)
+        if not daemon_ready.get("ok"):
+            raise SystemExit(f"error: daemon did not become ready: {daemon_ready}")
 
-    for q in queries:
-        relevant = set(q.relevant_files)
-        is_negative = not relevant
+    try:
+        for q in queries:
+            relevant = set(q.relevant_files)
+            is_negative = not relevant
 
-        rg_pattern = q.rg_pattern or re.escape(q.query)
-        t0 = time.monotonic()
-        rg_rank = _rg_rank_files(repo_root, pattern=rg_pattern, glob=glob_arg)
-        rg_time_s = time.monotonic() - t0
+            rg_pattern = q.rg_pattern or re.escape(q.query)
+            t0 = time.monotonic()
+            rg_rank = _rg_rank_files(repo_root, pattern=rg_pattern, glob=glob_arg)
+            rg_time_s = time.monotonic() - t0
 
-        sem_rank: list[str] | None = None
-        sem_time_s: float | None = None
-        if semantic_available:
-            if no_result_guard == "rg_empty" and not rg_rank:
-                sem_rank = []
-                sem_time_s = 0.0
-            else:
-                t0 = time.monotonic()
-                sem_rank = _semantic_rank_files(repo_root, index_ctx=index_ctx, query=q.query, k=effective_k)
-                sem_time_s = time.monotonic() - t0
-
-        hybrid_rank: list[str] | None = None
-        if sem_rank is not None:
-            hybrid_rank = _rrf_fuse([rg_rank[:max_k], sem_rank[:max_k]])
-        lane2_rank: list[str] | None = None
-        if lane2_enabled and semantic_available and index_ctx.paths is not None and index_ctx.config is not None:
-            from tldr.semantic import semantic_search
-
-            lane2_rows = semantic_search(
-                str(repo_root),
-                q.query,
-                k=max_k,
-                index_paths=index_ctx.paths,
-                index_config=index_ctx.config,
-                retrieval_mode="hybrid",
-                no_result_guard=no_result_guard,
-                rg_pattern=rg_pattern,
-                rg_glob=glob_arg,
-                abstain_threshold=args.lane2_abstain_threshold,
-                abstain_empty=bool(args.lane2_abstain_empty),
-                rerank=bool(args.lane2_rerank),
-                rerank_top_n=int(args.lane2_rerank_top_n),
-                max_latency_ms_p50_ratio=args.lane2_max_latency_ms_p50_ratio,
-                max_payload_tokens_median_ratio=args.lane2_max_payload_tokens_median_ratio,
-                budget_tokens=args.budget_tokens,
-            )
-            lane2_rank = _rank_files_from_result_rows(lane2_rows)
-
-        def record(method: str, ranking: list[str]) -> dict[str, Any]:
-            out = {
-                "mrr": _mrr(ranking, relevant) if relevant else None,
-                "top_files": ranking[:max_k],
-            }
-            for k in ks:
-                if relevant:
-                    out[f"recall@{k}"] = _recall_at_k(ranking, relevant, k)
-                    out[f"precision@{k}"] = _precision_at_k(ranking, relevant, k)
+            sem_rank: list[str] | None = None
+            sem_time_s: float | None = None
+            if semantic_available:
+                if no_result_guard == "rg_empty" and not rg_rank:
+                    sem_rank = []
+                    sem_time_s = 0.0
                 else:
-                    out[f"fpr@{k}"] = _fpr_at_k(ranking, k=k)
-            return out
+                    t0 = time.monotonic()
+                    sem_rank = _semantic_rank_files(
+                        repo_root,
+                        index_ctx=index_ctx,
+                        query=q.query,
+                        k=effective_k,
+                        use_daemon=bool(args.use_daemon),
+                    )
+                    sem_time_s = time.monotonic() - t0
 
-        q_res: dict[str, Any] = {
-            "id": q.id,
-            "query": q.query,
-            "relevant_files": list(q.relevant_files),
-            "no_result_guard_triggered": bool(no_result_guard == "rg_empty" and not rg_rank),
-            "rg": {
-                "pattern": rg_pattern,
-                "time_s": round(rg_time_s, 6),
-                **record("rg", rg_rank),
-            },
-            "semantic": None,
-            "hybrid_rrf": None,
-        }
-
-        if sem_rank is not None:
-            q_res["semantic"] = {
-                "time_s": round(float(sem_time_s or 0.0), 6),
-                **record("semantic", sem_rank),
-            }
-        else:
-            q_res["semantic"] = {"skipped": True, "reason": "semantic index artifacts missing"}
-
-        if hybrid_rank is not None:
-            q_res["hybrid_rrf"] = record("hybrid_rrf", hybrid_rank)
-        else:
-            q_res["hybrid_rrf"] = {"skipped": True, "reason": "semantic ranking unavailable"}
-        if lane2_enabled:
-            if lane2_rank is not None:
-                q_res["hybrid_lane2"] = record("hybrid_lane2", lane2_rank)
-            else:
-                q_res["hybrid_lane2"] = {"skipped": True, "reason": "semantic ranking unavailable"}
-
-        per_query.append(q_res)
-
-        # Aggregate metrics.
-        if is_negative:
-            for k in ks:
-                neg_fpr["rg"][f"fpr@{k}"].append(_fpr_at_k(rg_rank, k=k))
+            hybrid_rank: list[str] | None = None
             if sem_rank is not None:
-                for k in ks:
-                    neg_fpr["semantic"][f"fpr@{k}"].append(_fpr_at_k(sem_rank, k=k))
+                hybrid_rank = _rrf_fuse([rg_rank[:max_k], sem_rank[:max_k]])
+            lane2_rank: list[str] | None = None
+            if lane2_enabled and semantic_available and index_ctx.paths is not None and index_ctx.config is not None:
+                if args.use_daemon:
+                    lane2_res = query_daemon_ok(
+                        repo_root,
+                        index_ctx=index_ctx,
+                        command={
+                            "cmd": "semantic",
+                            "action": "search",
+                            "query": q.query,
+                            "k": max_k,
+                            "retrieval_mode": "hybrid",
+                            "no_result_guard": no_result_guard,
+                            "rg_pattern": rg_pattern,
+                            "rg_glob": glob_arg,
+                            "abstain_threshold": args.lane2_abstain_threshold,
+                            "abstain_empty": bool(args.lane2_abstain_empty),
+                            "rerank": bool(args.lane2_rerank),
+                            "rerank_top_n": int(args.lane2_rerank_top_n),
+                            "max_latency_ms_p50_ratio": args.lane2_max_latency_ms_p50_ratio,
+                            "max_payload_tokens_median_ratio": args.lane2_max_payload_tokens_median_ratio,
+                            "budget_tokens": args.budget_tokens,
+                        },
+                    )
+                    lane2_rows = lane2_res.get("results") or lane2_res.get("result") or []
+                else:
+                    from tldr.semantic import semantic_search
+
+                    lane2_rows = semantic_search(
+                        str(repo_root),
+                        q.query,
+                        k=max_k,
+                        index_paths=index_ctx.paths,
+                        index_config=index_ctx.config,
+                        retrieval_mode="hybrid",
+                        no_result_guard=no_result_guard,
+                        rg_pattern=rg_pattern,
+                        rg_glob=glob_arg,
+                        abstain_threshold=args.lane2_abstain_threshold,
+                        abstain_empty=bool(args.lane2_abstain_empty),
+                        rerank=bool(args.lane2_rerank),
+                        rerank_top_n=int(args.lane2_rerank_top_n),
+                        max_latency_ms_p50_ratio=args.lane2_max_latency_ms_p50_ratio,
+                        max_payload_tokens_median_ratio=args.lane2_max_payload_tokens_median_ratio,
+                        budget_tokens=args.budget_tokens,
+                    )
+                lane2_rank = _rank_files_from_result_rows(lane2_rows)
+
+            q_res: dict[str, Any] = {
+                "id": q.id,
+                "query": q.query,
+                "relevant_files": list(q.relevant_files),
+                "no_result_guard_triggered": bool(no_result_guard == "rg_empty" and not rg_rank),
+                "rg": {
+                    "pattern": rg_pattern,
+                    "time_s": round(rg_time_s, 6),
+                    **_record_ranking(rg_rank, relevant=relevant, ks=ks, max_k=max_k),
+                },
+                "semantic": None,
+                "hybrid_rrf": None,
+            }
+
+            if sem_rank is not None:
+                q_res["semantic"] = {
+                    "time_s": round(float(sem_time_s or 0.0), 6),
+                    **_record_ranking(sem_rank, relevant=relevant, ks=ks, max_k=max_k),
+                }
+            else:
+                q_res["semantic"] = {"skipped": True, "reason": "semantic index artifacts missing"}
+
             if hybrid_rank is not None:
+                q_res["hybrid_rrf"] = _record_ranking(hybrid_rank, relevant=relevant, ks=ks, max_k=max_k)
+            else:
+                q_res["hybrid_rrf"] = {"skipped": True, "reason": "semantic ranking unavailable"}
+            if lane2_enabled:
+                if lane2_rank is not None:
+                    q_res["hybrid_lane2"] = _record_ranking(
+                        lane2_rank,
+                        relevant=relevant,
+                        ks=ks,
+                        max_k=max_k,
+                    )
+                else:
+                    q_res["hybrid_lane2"] = {"skipped": True, "reason": "semantic ranking unavailable"}
+
+            per_query.append(q_res)
+
+            if is_negative:
                 for k in ks:
-                    neg_fpr["hybrid_rrf"][f"fpr@{k}"].append(_fpr_at_k(hybrid_rank, k=k))
-            if lane2_enabled and lane2_rank is not None:
-                for k in ks:
-                    neg_fpr["hybrid_lane2"][f"fpr@{k}"].append(_fpr_at_k(lane2_rank, k=k))
-        else:
+                    neg_fpr["rg"][f"fpr@{k}"].append(_fpr_at_k(rg_rank, k=k))
+                if sem_rank is not None:
+                    for k in ks:
+                        neg_fpr["semantic"][f"fpr@{k}"].append(_fpr_at_k(sem_rank, k=k))
+                if hybrid_rank is not None:
+                    for k in ks:
+                        neg_fpr["hybrid_rrf"][f"fpr@{k}"].append(_fpr_at_k(hybrid_rank, k=k))
+                if lane2_enabled and lane2_rank is not None:
+                    for k in ks:
+                        neg_fpr["hybrid_lane2"][f"fpr@{k}"].append(_fpr_at_k(lane2_rank, k=k))
+                continue
+
             agg["rg"]["mrr"].append(_mrr(rg_rank, relevant))
             for k in ks:
                 agg["rg"][f"recall@{k}"].append(_recall_at_k(rg_rank, relevant, k))
@@ -458,6 +528,9 @@ def main() -> int:
                 for k in ks:
                     agg["hybrid_lane2"][f"recall@{k}"].append(_recall_at_k(lane2_rank, relevant, k))
                     agg["hybrid_lane2"][f"precision@{k}"].append(_precision_at_k(lane2_rank, relevant, k))
+    finally:
+        if args.use_daemon:
+            stop_benchmark_daemon(repo_root, index_ctx=index_ctx)
 
     def summarize(xs: dict[str, list[float]]) -> dict[str, Any]:
         out: dict[str, Any] = {}
@@ -501,6 +574,8 @@ def main() -> int:
                 if semantic_available and index_ctx.paths is not None
                 else None
             ),
+            "use_daemon": bool(args.use_daemon),
+            "daemon_ready": daemon_ready,
         },
         results={
             "agg_positive": {

--- a/scripts/bench_structured_retrieval.py
+++ b/scripts/bench_structured_retrieval.py
@@ -1,0 +1,1026 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from bench_util import (
+    bench_cache_root,
+    bench_corpora_root,
+    bench_runs_root,
+    gather_meta,
+    get_repo_root,
+    make_report,
+    now_utc_compact,
+    percentiles,
+    query_daemon_ok,
+    restart_benchmark_daemon,
+    stop_benchmark_daemon,
+    write_report,
+)
+
+from tldr.indexing.index import IndexContext, get_index_context
+
+
+SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class StructuredTarget:
+    file: str
+    qualified_symbol: str | None
+    symbol_kind: str | None
+    start_line: int | None
+    end_line: int | None
+
+
+@dataclass(frozen=True)
+class StructuredQuery:
+    id: str
+    query: str
+    rg_pattern: str
+    targets: tuple[StructuredTarget, ...]
+
+
+@dataclass(frozen=True)
+class BackendSpec:
+    backend_id: str
+    kind: str
+    display_name: str
+    index_id: str | None = None
+    model: str | None = None
+    dimension: int | None = None
+    index_ctx: IndexContext | None = None
+    retrieval_mode: str = "semantic"
+    no_result_guard: str = "none"
+    rg_glob: str | None = None
+    rerank: bool = False
+    rerank_top_n: int = 5
+    projection_unit_k: int | None = None
+
+
+@dataclass(frozen=True)
+class Score:
+    tp: int
+    fp: int
+    fn: int
+
+    @property
+    def precision(self) -> float:
+        return self.tp / (self.tp + self.fp) if (self.tp + self.fp) else 1.0
+
+    @property
+    def recall(self) -> float:
+        return self.tp / (self.tp + self.fn) if (self.tp + self.fn) else 1.0
+
+    @property
+    def f1(self) -> float:
+        precision = self.precision
+        recall = self.recall
+        return (2.0 * precision * recall) / (precision + recall) if (precision + recall) else 0.0
+
+
+def _normalize_rel_path(value: str) -> str:
+    path = str(value or "").strip().replace("\\", "/")
+    if path.startswith("./"):
+        path = path[2:]
+    return path
+
+
+def _normalize_symbol_kind(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip().lower()
+    return text or None
+
+
+def _safe_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _target_to_dict(target: StructuredTarget, *, rank: int | None = None) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "file": target.file,
+        "qualified_symbol": target.qualified_symbol,
+        "symbol_kind": target.symbol_kind,
+        "start_line": target.start_line,
+        "end_line": target.end_line,
+    }
+    if rank is not None:
+        out["rank"] = int(rank)
+    return out
+
+
+def _load_queries(path: Path) -> list[StructuredQuery]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    raw_queries = data.get("queries") if isinstance(data, dict) else data
+    if not isinstance(raw_queries, list):
+        raise ValueError(f"bad structured retrieval query file: {path}")
+
+    queries: list[StructuredQuery] = []
+    for raw in raw_queries:
+        if not isinstance(raw, dict):
+            continue
+        query_id = raw.get("id")
+        query_text = raw.get("query")
+        rg_pattern = raw.get("rg_pattern")
+        raw_targets = raw.get("targets", [])
+        if not isinstance(query_id, str) or not isinstance(query_text, str) or not isinstance(rg_pattern, str):
+            continue
+        if not isinstance(raw_targets, list):
+            raise ValueError(f"query {query_id} has non-list targets")
+
+        targets: list[StructuredTarget] = []
+        for raw_target in raw_targets:
+            if not isinstance(raw_target, dict):
+                continue
+            file_path = _normalize_rel_path(str(raw_target.get("file") or ""))
+            if not file_path:
+                continue
+            qualified_symbol = raw_target.get("qualified_symbol")
+            start_line = _safe_int(raw_target.get("start_line"))
+            end_line = _safe_int(raw_target.get("end_line"))
+            if start_line is not None and end_line is None:
+                end_line = start_line
+            target = StructuredTarget(
+                file=file_path,
+                qualified_symbol=qualified_symbol if isinstance(qualified_symbol, str) and qualified_symbol.strip() else None,
+                symbol_kind=_normalize_symbol_kind(raw_target.get("symbol_kind")),
+                start_line=start_line,
+                end_line=end_line,
+            )
+            if _dedupe_identity_key(_target_to_dict(target)) is None:
+                raise ValueError(
+                    f"query {query_id} target must define a scoreable identity: {raw_target}"
+                )
+            targets.append(target)
+
+        queries.append(
+            StructuredQuery(
+                id=query_id,
+                query=query_text.strip(),
+                rg_pattern=rg_pattern,
+                targets=tuple(targets),
+            )
+        )
+    return queries
+
+
+def _symbol_key(item: dict[str, Any]) -> tuple[str, str] | None:
+    file_path = item.get("file")
+    symbol = item.get("qualified_symbol")
+    if isinstance(file_path, str) and file_path and isinstance(symbol, str) and symbol:
+        return (file_path, symbol)
+    return None
+
+
+def _span_key(item: dict[str, Any]) -> tuple[str, int, int] | None:
+    file_path = item.get("file")
+    start_line = _safe_int(item.get("start_line"))
+    end_line = _safe_int(item.get("end_line"))
+    if isinstance(file_path, str) and file_path and start_line is not None and end_line is not None:
+        return (file_path, start_line, end_line)
+    return None
+
+
+def _dedupe_identity_key(item: dict[str, Any]) -> tuple[Any, ...] | None:
+    symbol_key = _symbol_key(item)
+    if symbol_key is not None:
+        return ("symbol",) + symbol_key
+    span_key = _span_key(item)
+    if span_key is not None:
+        return ("span",) + span_key
+    return None
+
+
+def _dedupe_items(items: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], int]:
+    deduped: list[dict[str, Any]] = []
+    seen: set[tuple[Any, ...]] = set()
+    unscorable = 0
+    for item in items:
+        key = _dedupe_identity_key(item)
+        if key is None:
+            unscorable += 1
+            continue
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(dict(item))
+    return deduped, unscorable
+
+
+def _score_structured_predictions(
+    targets: list[dict[str, Any]],
+    predictions: list[dict[str, Any]],
+) -> dict[str, Any]:
+    gold, unscorable_gold = _dedupe_items(targets)
+    got, unscorable_predictions = _dedupe_items(predictions)
+
+    unmatched_gold = set(range(len(gold)))
+    unmatched_predictions = set(range(len(got)))
+    matched_pairs: list[dict[str, Any]] = []
+
+    gold_symbol_map: dict[tuple[str, str], list[int]] = {}
+    for idx, item in enumerate(gold):
+        key = _symbol_key(item)
+        if key is not None:
+            gold_symbol_map.setdefault(key, []).append(idx)
+
+    for pred_idx, pred in enumerate(got):
+        pred_symbol = _symbol_key(pred)
+        if pred_symbol is None:
+            continue
+        candidates = gold_symbol_map.get(pred_symbol, [])
+        match_idx = next((idx for idx in candidates if idx in unmatched_gold), None)
+        if match_idx is None:
+            continue
+        unmatched_gold.remove(match_idx)
+        unmatched_predictions.remove(pred_idx)
+        matched_pairs.append(
+            {
+                "mode": "symbol",
+                "prediction": dict(pred),
+                "target": dict(gold[match_idx]),
+            }
+        )
+
+    gold_span_map: dict[tuple[str, int, int], list[int]] = {}
+    for idx in unmatched_gold:
+        key = _span_key(gold[idx])
+        if key is not None:
+            gold_span_map.setdefault(key, []).append(idx)
+
+    for pred_idx, pred in enumerate(got):
+        if pred_idx not in unmatched_predictions:
+            continue
+        pred_span = _span_key(pred)
+        if pred_span is None:
+            continue
+        candidates = gold_span_map.get(pred_span, [])
+        match_idx = None
+        for candidate_idx in candidates:
+            if candidate_idx not in unmatched_gold:
+                continue
+            gold_has_symbol = _symbol_key(gold[candidate_idx]) is not None
+            pred_has_symbol = _symbol_key(pred) is not None
+            if gold_has_symbol and pred_has_symbol:
+                continue
+            match_idx = candidate_idx
+            break
+        if match_idx is None:
+            continue
+        unmatched_gold.remove(match_idx)
+        unmatched_predictions.remove(pred_idx)
+        matched_pairs.append(
+            {
+                "mode": "span",
+                "prediction": dict(pred),
+                "target": dict(gold[match_idx]),
+            }
+        )
+
+    score = Score(
+        tp=len(matched_pairs),
+        fp=len(unmatched_predictions),
+        fn=len(unmatched_gold),
+    )
+    return {
+        "tp": int(score.tp),
+        "fp": int(score.fp),
+        "fn": int(score.fn),
+        "precision": float(score.precision),
+        "recall": float(score.recall),
+        "f1": float(score.f1),
+        "gold_targets": gold,
+        "predictions": got,
+        "matched_pairs": matched_pairs,
+        "unmatched_gold": [gold[idx] for idx in sorted(unmatched_gold)],
+        "unmatched_predictions": [got[idx] for idx in sorted(unmatched_predictions)],
+        "unscorable_gold_targets": int(unscorable_gold),
+        "unscorable_predictions": int(unscorable_predictions),
+    }
+
+
+def _load_semantic_metadata(index_ctx: IndexContext) -> dict[str, Any] | None:
+    paths = getattr(index_ctx, "paths", None)
+    if paths is None or not paths.semantic_metadata.exists():
+        return None
+    try:
+        return json.loads(paths.semantic_metadata.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _default_semantic_backends(corpus_id: str | None) -> list[str]:
+    if corpus_id == "django":
+        return ["bge=repo:django-bge", "jina05b=repo:django-jina05b"]
+    return []
+
+
+def _parse_semantic_backend_arg(value: str) -> tuple[str, str]:
+    text = str(value or "").strip()
+    if not text or "=" not in text:
+        raise ValueError(f"bad --semantic-backend value: {value!r}")
+    label, index_id = text.split("=", 1)
+    label = label.strip()
+    index_id = index_id.strip()
+    if not label or not index_id:
+        raise ValueError(f"bad --semantic-backend value: {value!r}")
+    return (label, index_id)
+
+
+def _rg_structured_predictions(
+    repo_root: Path,
+    *,
+    pattern: str,
+    top_k: int,
+    glob: str | None,
+) -> list[dict[str, Any]]:
+    argv = ["rg", "--json", "--line-number", "--no-messages"]
+    if isinstance(glob, str) and glob.strip():
+        argv.extend(["--glob", glob.strip()])
+    argv.extend(["--", pattern, "."])
+    proc = subprocess.run(
+        argv,
+        cwd=str(repo_root),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode not in (0, 1):
+        stderr = str(proc.stderr or "").strip()
+        raise RuntimeError(f"rg failed with exit={proc.returncode}: {stderr}")
+
+    raw_matches: list[dict[str, Any]] = []
+    file_hit_counts: dict[str, int] = {}
+    for raw_line in str(proc.stdout or "").splitlines():
+        try:
+            event = json.loads(raw_line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict) or event.get("type") != "match":
+            continue
+        data = event.get("data")
+        if not isinstance(data, dict):
+            continue
+        path_obj = data.get("path")
+        if not isinstance(path_obj, dict):
+            continue
+        path_text = path_obj.get("text")
+        if not isinstance(path_text, str):
+            continue
+        file_path = _normalize_rel_path(path_text)
+        line_number = _safe_int(data.get("line_number"))
+        if not file_path or line_number is None:
+            continue
+        raw_matches.append(
+            {
+                "file": file_path,
+                "qualified_symbol": None,
+                "symbol_kind": "unknown",
+                "start_line": int(line_number),
+                "end_line": int(line_number),
+            }
+        )
+        file_hit_counts[file_path] = file_hit_counts.get(file_path, 0) + 1
+
+    raw_matches.sort(
+        key=lambda item: (
+            -file_hit_counts.get(str(item.get("file") or ""), 0),
+            int(item.get("start_line") or 0),
+            str(item.get("file") or ""),
+        )
+    )
+
+    ranked: list[dict[str, Any]] = []
+    for rank, item in enumerate(raw_matches, start=1):
+        entry = dict(item)
+        entry["rank"] = int(rank)
+        ranked.append(entry)
+
+    deduped, _ = _dedupe_items(ranked)
+    limited = deduped[: max(0, int(top_k))]
+    for rank, item in enumerate(limited, start=1):
+        item["rank"] = int(rank)
+    return limited
+
+
+def _semantic_structured_predictions(
+    repo_root: Path,
+    *,
+    backend: BackendSpec,
+    query: str,
+    top_k: int,
+    use_daemon: bool,
+    rg_pattern: str | None = None,
+) -> list[dict[str, Any]]:
+    rows = _semantic_search_rows(
+        repo_root,
+        backend=backend,
+        query=query,
+        top_k=int(top_k),
+        use_daemon=use_daemon,
+        retrieval_mode="semantic",
+        rg_pattern=rg_pattern,
+    )
+    predictions = _rows_to_structured_predictions(rows)
+    deduped, _ = _dedupe_items(predictions)
+    limited = deduped[: max(0, int(top_k))]
+    for rank, item in enumerate(limited, start=1):
+        item["rank"] = int(rank)
+    return limited
+
+
+def _semantic_search_rows(
+    repo_root: Path,
+    *,
+    backend: BackendSpec,
+    query: str,
+    top_k: int,
+    use_daemon: bool,
+    retrieval_mode: str = "semantic",
+    rg_pattern: str | None = None,
+) -> list[dict[str, Any]]:
+    if backend.index_ctx is None:
+        return []
+    glob_arg = backend.rg_glob if isinstance(backend.rg_glob, str) and backend.rg_glob.strip() else None
+    if use_daemon:
+        command: dict[str, Any] = {
+            "cmd": "semantic",
+            "action": "search",
+            "query": query,
+            "k": int(top_k),
+            "model": backend.model,
+            "retrieval_mode": retrieval_mode,
+            "no_result_guard": backend.no_result_guard,
+            "rerank": bool(backend.rerank),
+            "rerank_top_n": int(backend.rerank_top_n),
+        }
+        if isinstance(rg_pattern, str) and rg_pattern.strip():
+            command["rg_pattern"] = rg_pattern
+        if glob_arg is not None:
+            command["rg_glob"] = glob_arg
+        response = query_daemon_ok(
+            repo_root,
+            index_ctx=backend.index_ctx,
+            command=command,
+        )
+        rows = response.get("results") or response.get("result") or []
+    else:
+        from tldr.semantic import semantic_search
+
+        rows = semantic_search(
+            str(repo_root),
+            query,
+            k=int(top_k),
+            model=backend.model,
+            index_paths=getattr(backend.index_ctx, "paths", None),
+            index_config=getattr(backend.index_ctx, "config", None),
+            retrieval_mode=retrieval_mode,
+            no_result_guard=backend.no_result_guard,
+            rg_pattern=rg_pattern,
+            rg_glob=glob_arg,
+            rerank=bool(backend.rerank),
+            rerank_top_n=int(backend.rerank_top_n),
+        )
+    return [dict(row) for row in rows or [] if isinstance(row, dict)]
+
+
+def _row_to_structured_prediction(row: dict[str, Any], *, rank: int) -> dict[str, Any] | None:
+    file_path = row.get("file") or row.get("path")
+    if not isinstance(file_path, str):
+        return None
+    qualified_symbol = None
+    if isinstance(row.get("qualified_name"), str):
+        qualified_symbol = row.get("qualified_name")
+    else:
+        symbol_obj = row.get("symbol")
+        if isinstance(symbol_obj, dict) and isinstance(symbol_obj.get("qualified_name"), str):
+            qualified_symbol = symbol_obj.get("qualified_name")
+    start_line = _safe_int(row.get("line"))
+    if start_line is None:
+        start_line = _safe_int(row.get("start_line"))
+    end_line = _safe_int(row.get("end_line"))
+    if start_line is not None and end_line is None:
+        end_line = start_line
+    return {
+        "file": _normalize_rel_path(file_path),
+        "qualified_symbol": qualified_symbol if isinstance(qualified_symbol, str) and qualified_symbol.strip() else None,
+        "symbol_kind": _normalize_symbol_kind(row.get("unit_type") or row.get("symbol_kind")),
+        "start_line": start_line,
+        "end_line": end_line,
+        "rank": int(rank),
+    }
+
+
+def _rows_to_structured_predictions(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    predictions: list[dict[str, Any]] = []
+    for rank, row in enumerate(rows or [], start=1):
+        prediction = _row_to_structured_prediction(row, rank=rank)
+        if prediction is not None:
+            predictions.append(prediction)
+    return predictions
+
+
+def _hybrid_structured_predictions(
+    repo_root: Path,
+    *,
+    backend: BackendSpec,
+    query: str,
+    rg_pattern: str,
+    top_k: int,
+    use_daemon: bool,
+) -> list[dict[str, Any]]:
+    file_rows = _semantic_search_rows(
+        repo_root,
+        backend=backend,
+        query=query,
+        top_k=int(top_k),
+        use_daemon=use_daemon,
+        retrieval_mode="hybrid",
+        rg_pattern=rg_pattern,
+    )
+    if not file_rows:
+        return []
+
+    file_rank_by_path: dict[str, int] = {}
+    for rank, row in enumerate(file_rows, start=1):
+        file_path = row.get("file") or row.get("path")
+        if not isinstance(file_path, str):
+            continue
+        normalized = _normalize_rel_path(file_path)
+        if normalized and normalized not in file_rank_by_path:
+            file_rank_by_path[normalized] = int(rank)
+    if not file_rank_by_path:
+        return []
+
+    projection_unit_k = backend.projection_unit_k
+    if projection_unit_k is None:
+        projection_unit_k = max(int(top_k) * 20, 100)
+    unit_rows = _semantic_search_rows(
+        repo_root,
+        backend=backend,
+        query=query,
+        top_k=max(int(top_k), int(projection_unit_k)),
+        use_daemon=use_daemon,
+        retrieval_mode="semantic",
+    )
+
+    candidates: list[dict[str, Any]] = []
+    for semantic_rank, row in enumerate(unit_rows, start=1):
+        prediction = _row_to_structured_prediction(row, rank=semantic_rank)
+        if prediction is None:
+            continue
+        file_rank = file_rank_by_path.get(str(prediction.get("file") or ""))
+        if file_rank is None:
+            continue
+        prediction["hybrid_file_rank"] = int(file_rank)
+        prediction["semantic_rank"] = int(semantic_rank)
+        candidates.append(prediction)
+
+    candidates.sort(
+        key=lambda item: (
+            int(item.get("hybrid_file_rank") or 0),
+            int(item.get("semantic_rank") or 0),
+            str(item.get("file") or ""),
+            str(item.get("qualified_symbol") or ""),
+            int(item.get("start_line") or 0),
+        )
+    )
+    deduped, _ = _dedupe_items(candidates)
+    limited = deduped[: max(0, int(top_k))]
+    for rank, item in enumerate(limited, start=1):
+        item["rank"] = int(rank)
+    return limited
+
+
+def _finalize_backend_summary(acc: dict[str, Any]) -> dict[str, Any]:
+    micro = Score(tp=int(acc["tp"]), fp=int(acc["fp"]), fn=int(acc["fn"]))
+    latency_values = [float(value) for value in acc["latency_ms"]]
+    latency_percentiles = percentiles(latency_values, ps=[0.5, 0.95]) if latency_values else {}
+    macro_precision = statistics.mean(acc["precision"]) if acc["precision"] else None
+    macro_recall = statistics.mean(acc["recall"]) if acc["recall"] else None
+    macro_f1 = statistics.mean(acc["f1"]) if acc["f1"] else None
+    return {
+        "n_queries": int(acc["n_queries"]),
+        "micro": {
+            "tp": int(micro.tp),
+            "fp": int(micro.fp),
+            "fn": int(micro.fn),
+            "precision": float(micro.precision),
+            "recall": float(micro.recall),
+            "f1": float(micro.f1),
+        },
+        "macro": {
+            "precision_mean": float(macro_precision) if macro_precision is not None else None,
+            "recall_mean": float(macro_recall) if macro_recall is not None else None,
+            "f1_mean": float(macro_f1) if macro_f1 is not None else None,
+        },
+        "latency_ms": {
+            "p50": float(latency_percentiles.get("p50", 0.0)),
+            "p95": float(latency_percentiles.get("p95", 0.0)),
+            "mean": float(statistics.mean(latency_values)) if latency_values else 0.0,
+        },
+        "unscorable_predictions": int(acc["unscorable_predictions"]),
+        "unscorable_gold_targets": int(acc["unscorable_gold_targets"]),
+    }
+
+
+def _compare_backend_summaries(
+    lhs: str,
+    rhs: str,
+    *,
+    summaries: dict[str, dict[str, Any]],
+) -> dict[str, Any] | None:
+    lhs_summary = summaries.get(lhs)
+    rhs_summary = summaries.get(rhs)
+    if not isinstance(lhs_summary, dict) or not isinstance(rhs_summary, dict):
+        return None
+
+    lhs_f1 = float(lhs_summary["micro"]["f1"])
+    rhs_f1 = float(rhs_summary["micro"]["f1"])
+    lhs_p50 = float(lhs_summary["latency_ms"]["p50"])
+    rhs_p50 = float(rhs_summary["latency_ms"]["p50"])
+
+    winner = "tie"
+    if lhs_f1 > rhs_f1:
+        winner = lhs
+    elif rhs_f1 > lhs_f1:
+        winner = rhs
+
+    return {
+        "lhs": lhs,
+        "rhs": rhs,
+        "micro_f1_delta": float(lhs_f1 - rhs_f1),
+        "micro_precision_delta": float(lhs_summary["micro"]["precision"] - rhs_summary["micro"]["precision"]),
+        "micro_recall_delta": float(lhs_summary["micro"]["recall"] - rhs_summary["micro"]["recall"]),
+        "latency_ms_p50_delta": float(lhs_p50 - rhs_p50),
+        "winner_by_micro_f1": winner,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(
+        description=(
+            "Deterministic structured retrieval benchmark "
+            "(rg-native vs TLDR semantic and optional hybrid backends)."
+        )
+    )
+    group = ap.add_mutually_exclusive_group(required=True)
+    group.add_argument("--corpus", default=None, help="Corpus id under benchmark/corpora/ (e.g. django).")
+    group.add_argument("--repo-root", default=None, help="Corpus repo root.")
+    ap.add_argument(
+        "--queries",
+        default=str(get_repo_root() / "benchmarks" / "retrieval" / "django_structured_queries.json"),
+        help="Structured retrieval query manifest.",
+    )
+    ap.add_argument(
+        "--cache-root",
+        default=str(bench_cache_root(get_repo_root())),
+        help="Index-mode cache root.",
+    )
+    ap.add_argument(
+        "--semantic-backend",
+        action="append",
+        default=[],
+        help="Repeated LABEL=INDEX_ID mapping. Default for django: bge=repo:django-bge and jina05b=repo:django-jina05b.",
+    )
+    ap.add_argument(
+        "--top-k",
+        type=int,
+        default=10,
+        help="Maximum number of structured rows to score per backend/query.",
+    )
+    ap.add_argument(
+        "--rg-glob",
+        default="*.py",
+        help="Optional rg --glob filter for the native lexical baseline.",
+    )
+    ap.add_argument(
+        "--use-daemon",
+        action="store_true",
+        help="Route TLDR semantic queries through the daemon for repeated-query benchmarking.",
+    )
+    ap.add_argument(
+        "--include-hybrid",
+        action="store_true",
+        help=(
+            "Also benchmark hybrid file retrieval projected back to structured unit predictions "
+            "via semantic-unit rows from the same top files."
+        ),
+    )
+    ap.add_argument(
+        "--hybrid-no-result-guard",
+        choices=["none", "rg_empty"],
+        default="none",
+        help="Guard mode for hybrid retrieval (default: none).",
+    )
+    ap.add_argument(
+        "--hybrid-rerank",
+        action="store_true",
+        help="Enable deterministic reranking on hybrid file rows before unit projection.",
+    )
+    ap.add_argument(
+        "--hybrid-rerank-top-n",
+        type=int,
+        default=5,
+        help="Top-N candidate files considered by --hybrid-rerank (default: 5).",
+    )
+    ap.add_argument(
+        "--hybrid-projection-unit-k",
+        type=int,
+        default=100,
+        help=(
+            "Semantic-unit candidate count used to project hybrid file hits back to structured "
+            "predictions (default: 100)."
+        ),
+    )
+    ap.add_argument(
+        "--out",
+        default=None,
+        help="Write JSON report here (default: benchmark/runs/<timestamp>-structured-retrieval-<corpus>.json).",
+    )
+    return ap
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+
+    tldr_repo_root = get_repo_root()
+    corpus_id = str(args.corpus) if args.corpus else None
+    if corpus_id:
+        repo_root = (bench_corpora_root(tldr_repo_root) / corpus_id).resolve()
+    else:
+        repo_root = Path(args.repo_root).resolve()
+        corpus_id = repo_root.name
+    if not repo_root.exists():
+        raise SystemExit(f"error: repo-root does not exist: {repo_root}")
+
+    queries_path = Path(args.queries).resolve()
+    queries = _load_queries(queries_path)
+
+    semantic_backend_args = list(args.semantic_backend or ())
+    if not semantic_backend_args:
+        semantic_backend_args = _default_semantic_backends(corpus_id)
+
+    semantic_backends: list[BackendSpec] = []
+    for raw_backend in semantic_backend_args:
+        label, index_id = _parse_semantic_backend_arg(raw_backend)
+        index_ctx = get_index_context(
+            scan_root=repo_root,
+            cache_root_arg=args.cache_root,
+            index_id_arg=index_id,
+            allow_create=True,
+        )
+        meta = _load_semantic_metadata(index_ctx)
+        semantic_backends.append(
+            BackendSpec(
+                backend_id=label,
+                kind="semantic",
+                display_name=f"{label} ({meta.get('model') if isinstance(meta, dict) else index_id})",
+                index_id=index_id,
+                model=meta.get("model") if isinstance(meta, dict) and isinstance(meta.get("model"), str) else None,
+                dimension=_safe_int(meta.get("dimension")) if isinstance(meta, dict) else None,
+                index_ctx=index_ctx,
+            )
+        )
+
+    backends: list[BackendSpec] = [
+        BackendSpec(
+            backend_id="rg_native",
+            kind="rg_native",
+            display_name="rg-native (lexical)",
+        )
+    ]
+    backends.extend(semantic_backends)
+    if args.include_hybrid:
+        backends.extend(
+            BackendSpec(
+                backend_id=f"{backend.backend_id}_hybrid",
+                kind="semantic_hybrid",
+                display_name=f"{backend.backend_id} hybrid ({backend.model or backend.index_id})",
+                index_id=backend.index_id,
+                model=backend.model,
+                dimension=backend.dimension,
+                index_ctx=backend.index_ctx,
+                retrieval_mode="hybrid",
+                no_result_guard=str(args.hybrid_no_result_guard),
+                rg_glob=str(args.rg_glob) if str(args.rg_glob).strip() else None,
+                rerank=bool(args.hybrid_rerank),
+                rerank_top_n=int(args.hybrid_rerank_top_n),
+                projection_unit_k=int(args.hybrid_projection_unit_k),
+            )
+            for backend in semantic_backends
+        )
+
+    daemon_ready: dict[str, Any] = {}
+    if args.use_daemon:
+        for backend in semantic_backends:
+            if backend.index_ctx is None:
+                continue
+            ready = restart_benchmark_daemon(repo_root, index_ctx=backend.index_ctx)
+            if not ready.get("ok"):
+                raise SystemExit(
+                    f"error: daemon did not become ready for {backend.backend_id}: {ready}"
+                )
+            daemon_ready[backend.backend_id] = ready
+
+    accumulators: dict[str, dict[str, Any]] = {
+        backend.backend_id: {
+            "tp": 0,
+            "fp": 0,
+            "fn": 0,
+            "n_queries": 0,
+            "precision": [],
+            "recall": [],
+            "f1": [],
+            "latency_ms": [],
+            "unscorable_predictions": 0,
+            "unscorable_gold_targets": 0,
+        }
+        for backend in backends
+    }
+
+    per_query: list[dict[str, Any]] = []
+    try:
+        for query in queries:
+            gold_targets = [_target_to_dict(target) for target in query.targets]
+            row: dict[str, Any] = {
+                "id": query.id,
+                "query": query.query,
+                "rg_pattern": query.rg_pattern,
+                "targets": gold_targets,
+                "backends": {},
+            }
+
+            for backend in backends:
+                started = time.monotonic()
+                if backend.kind == "rg_native":
+                    predictions = _rg_structured_predictions(
+                        repo_root,
+                        pattern=query.rg_pattern,
+                        top_k=int(args.top_k),
+                        glob=args.rg_glob,
+                    )
+                elif backend.kind == "semantic_hybrid":
+                    predictions = _hybrid_structured_predictions(
+                        repo_root,
+                        backend=backend,
+                        query=query.query,
+                        rg_pattern=query.rg_pattern,
+                        top_k=int(args.top_k),
+                        use_daemon=bool(args.use_daemon),
+                    )
+                else:
+                    predictions = _semantic_structured_predictions(
+                        repo_root,
+                        backend=backend,
+                        query=query.query,
+                        top_k=int(args.top_k),
+                        use_daemon=bool(args.use_daemon),
+                        rg_pattern=query.rg_pattern,
+                    )
+                elapsed_ms = (time.monotonic() - started) * 1000.0
+
+                scored = _score_structured_predictions(gold_targets, predictions)
+                row["backends"][backend.backend_id] = {
+                    "backend_id": backend.backend_id,
+                    "display_name": backend.display_name,
+                    "latency_ms": float(elapsed_ms),
+                    "prediction_count": int(len(scored["predictions"])),
+                    "tp": int(scored["tp"]),
+                    "fp": int(scored["fp"]),
+                    "fn": int(scored["fn"]),
+                    "precision": float(scored["precision"]),
+                    "recall": float(scored["recall"]),
+                    "f1": float(scored["f1"]),
+                    "predictions": scored["predictions"],
+                    "matched_pairs": scored["matched_pairs"],
+                    "unmatched_gold": scored["unmatched_gold"],
+                    "unmatched_predictions": scored["unmatched_predictions"],
+                    "unscorable_predictions": int(scored["unscorable_predictions"]),
+                    "unscorable_gold_targets": int(scored["unscorable_gold_targets"]),
+                }
+
+                acc = accumulators[backend.backend_id]
+                acc["tp"] += int(scored["tp"])
+                acc["fp"] += int(scored["fp"])
+                acc["fn"] += int(scored["fn"])
+                acc["n_queries"] += 1
+                acc["precision"].append(float(scored["precision"]))
+                acc["recall"].append(float(scored["recall"]))
+                acc["f1"].append(float(scored["f1"]))
+                acc["latency_ms"].append(float(elapsed_ms))
+                acc["unscorable_predictions"] += int(scored["unscorable_predictions"])
+                acc["unscorable_gold_targets"] += int(scored["unscorable_gold_targets"])
+
+            per_query.append(row)
+    finally:
+        if args.use_daemon:
+            for backend in reversed(semantic_backends):
+                if backend.index_ctx is None:
+                    continue
+                stop_benchmark_daemon(repo_root, index_ctx=backend.index_ctx)
+
+    summaries = {
+        backend_id: _finalize_backend_summary(acc)
+        for backend_id, acc in accumulators.items()
+    }
+
+    comparisons: list[dict[str, Any]] = []
+    comparison_pairs: list[tuple[str, str]] = []
+    for backend in backends:
+        if backend.backend_id != "rg_native":
+            comparison_pairs.append((backend.backend_id, "rg_native"))
+    available_ids = {backend.backend_id for backend in backends}
+    for lhs, rhs in (
+        ("jina05b", "bge"),
+        ("jina05b_hybrid", "bge_hybrid"),
+        ("bge_hybrid", "bge"),
+        ("jina05b_hybrid", "jina05b"),
+    ):
+        if lhs in available_ids and rhs in available_ids:
+            comparison_pairs.append((lhs, rhs))
+    seen_pairs: set[tuple[str, str]] = set()
+    for lhs, rhs in comparison_pairs:
+        pair = (lhs, rhs)
+        if pair in seen_pairs:
+            continue
+        seen_pairs.add(pair)
+        comparison = _compare_backend_summaries(lhs, rhs, summaries=summaries)
+        if comparison is not None:
+            comparisons.append(comparison)
+
+    protocol_backends: list[dict[str, Any]] = []
+    for backend in backends:
+        backend_entry = {
+            "backend_id": backend.backend_id,
+            "kind": backend.kind,
+            "display_name": backend.display_name,
+        }
+        if backend.index_id is not None:
+            backend_entry["index_id"] = backend.index_id
+        if backend.model is not None:
+            backend_entry["semantic_model"] = backend.model
+        if backend.dimension is not None:
+            backend_entry["semantic_dimension"] = backend.dimension
+        if backend.retrieval_mode != "semantic":
+            backend_entry["retrieval_mode"] = backend.retrieval_mode
+            backend_entry["no_result_guard"] = backend.no_result_guard
+            backend_entry["rerank"] = bool(backend.rerank)
+            backend_entry["rerank_top_n"] = int(backend.rerank_top_n)
+            if backend.projection_unit_k is not None:
+                backend_entry["projection_unit_k"] = int(backend.projection_unit_k)
+            if backend.rg_glob is not None:
+                backend_entry["rg_glob"] = backend.rg_glob
+        if backend.backend_id in daemon_ready:
+            backend_entry["daemon_ready"] = daemon_ready[backend.backend_id]
+        protocol_backends.append(backend_entry)
+
+    report = make_report(
+        phase="phase5_structured_retrieval",
+        meta=gather_meta(tldr_repo_root=tldr_repo_root, corpus_id=corpus_id, corpus_root=repo_root),
+        protocol={
+            "schema_version": SCHEMA_VERSION,
+            "feature_set_id": "feature.structured-retrieval.v1",
+            "queries": str(queries_path),
+            "cache_root": str(Path(args.cache_root).resolve()),
+            "top_k": int(args.top_k),
+            "use_daemon": bool(args.use_daemon),
+            "include_hybrid": bool(args.include_hybrid),
+            "hybrid_no_result_guard": str(args.hybrid_no_result_guard),
+            "hybrid_rerank": bool(args.hybrid_rerank),
+            "hybrid_rerank_top_n": int(args.hybrid_rerank_top_n),
+            "hybrid_projection_unit_k": int(args.hybrid_projection_unit_k),
+            "backends": protocol_backends,
+            "rg_glob": str(args.rg_glob),
+        },
+        results={
+            "by_backend": summaries,
+            "comparisons": comparisons,
+            "per_query": per_query,
+        },
+        schema_version=SCHEMA_VERSION,
+    )
+
+    out_path = Path(args.out).resolve() if args.out else (
+        bench_runs_root(tldr_repo_root) / f"{now_utc_compact()}-structured-retrieval-{corpus_id}.json"
+    )
+    write_report(out_path, report)
+    print(str(out_path))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench_token_efficiency.py
+++ b/scripts/bench_token_efficiency.py
@@ -19,6 +19,9 @@ from bench_util import (
     get_repo_root,
     make_report,
     now_utc_compact,
+    query_daemon_ok,
+    restart_benchmark_daemon,
+    stop_benchmark_daemon,
     write_report,
 )
 
@@ -521,6 +524,7 @@ def _semantic_rank_files(
     index_ctx: IndexContext,
     query: str,
     k: int,
+    use_daemon: bool = False,
 ) -> list[str] | None:
     paths = index_ctx.paths
     cfg = index_ctx.config
@@ -529,15 +533,28 @@ def _semantic_rank_files(
     if not (paths.semantic_faiss.exists() and paths.semantic_metadata.exists()):
         return None
 
-    from tldr.semantic import semantic_search
+    if use_daemon:
+        res = query_daemon_ok(
+            repo_root,
+            index_ctx=index_ctx,
+            command={
+                "cmd": "semantic",
+                "action": "search",
+                "query": query,
+                "k": int(k),
+            },
+        )
+        results = res.get("results") or res.get("result") or []
+    else:
+        from tldr.semantic import semantic_search
 
-    results = semantic_search(
-        str(repo_root),
-        query,
-        k=int(k),
-        index_paths=paths,
-        index_config=cfg,
-    )
+        results = semantic_search(
+            str(repo_root),
+            query,
+            k=int(k),
+            index_paths=paths,
+            index_config=cfg,
+        )
 
     ranked: list[str] = []
     for r in results or []:
@@ -856,6 +873,11 @@ def main() -> int:
             "'rg_empty' suppresses semantic/hybrid when rg finds no matches for the query's rg_pattern."
         ),
     )
+    ap.add_argument(
+        "--use-daemon",
+        action="store_true",
+        help="Route semantic queries through the daemon instead of in-process API calls.",
+    )
     ap.add_argument("--out", default=None, help="Write JSON report to this path (default under benchmark/runs/).")
     args = ap.parse_args()
 
@@ -885,6 +907,11 @@ def main() -> int:
     glob = str(args.rg_glob)
     glob_arg = glob if glob.strip() else None
     retrieval_no_result_guard = str(args.no_result_guard)
+    daemon_ready: dict[str, Any] | None = None
+    if args.use_daemon:
+        daemon_ready = restart_benchmark_daemon(repo_root, index_ctx=index_ctx)
+        if not daemon_ready.get("ok"):
+            raise SystemExit(f"error: daemon did not become ready: {daemon_ready}")
 
     results: dict[str, Any] = {}
 
@@ -2000,7 +2027,13 @@ def main() -> int:
                 if retrieval_no_result_guard == "rg_empty" and not rg_rank:
                     sem_rank = []
                 else:
-                    sem_rank = _semantic_rank_files(repo_root, index_ctx=index_ctx, query=q.query, k=max_files) or []
+                    sem_rank = _semantic_rank_files(
+                        repo_root,
+                        index_ctx=index_ctx,
+                        query=q.query,
+                        k=max_files,
+                        use_daemon=bool(args.use_daemon),
+                    ) or []
                     sem_rank = sem_rank[:max_files]
 
             hybrid_rank = _rrf_fuse([rg_rank, sem_rank])[:max_files] if sem_rank is not None else None
@@ -2114,6 +2147,8 @@ def main() -> int:
             "index_id": index_ctx.index_id,
             "rg_glob": glob_arg,
             "retrieval_no_result_guard": retrieval_no_result_guard if args.mode in ("retrieval", "both") else None,
+            "use_daemon": bool(args.use_daemon),
+            "daemon_ready": daemon_ready,
         },
         results=results,
     )
@@ -2125,6 +2160,8 @@ def main() -> int:
         out_path = bench_runs_root(tldr_repo_root) / f"{ts}-token-efficiency-{corpus_id}.json"
     write_report(out_path, report)
     print(out_path)
+    if args.use_daemon:
+        stop_benchmark_daemon(repo_root, index_ctx=index_ctx)
     return 0
 
 

--- a/scripts/bench_util.py
+++ b/scripts/bench_util.py
@@ -4,6 +4,7 @@ import json
 import platform
 import subprocess
 import sys
+import time
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -196,3 +197,97 @@ def load_corpora_manifest(path: Path) -> dict[str, Any]:
     if not isinstance(data.get("corpora"), list):
         raise ValueError(f"Bad corpora manifest 'corpora' field: {path}")
     return data
+
+
+def restart_benchmark_daemon(
+    repo_root: Path,
+    *,
+    index_ctx: Any,
+    timeout_s: float = 10.0,
+) -> dict[str, Any]:
+    from tldr.daemon.startup import query_daemon, stop_daemon
+
+    try:
+        stop_daemon(repo_root, index_ctx=index_ctx)
+    except Exception:
+        pass
+
+    argv = [
+        sys.executable,
+        "-m",
+        "tldr.daemon.startup",
+        str(repo_root),
+        "--cache-root",
+        str(index_ctx.cache_root),
+        "--index",
+        str(index_ctx.index_id),
+        "--foreground",
+    ]
+    cfg = getattr(index_ctx, "config", None)
+    if cfg is not None:
+        ignore_file = getattr(cfg, "ignore_file", None)
+        if ignore_file is not None:
+            argv.extend(["--ignore-file", str(ignore_file)])
+        if getattr(cfg, "no_ignore", False):
+            argv.append("--no-ignore")
+        elif getattr(cfg, "use_gitignore", True) is False:
+            argv.append("--no-gitignore")
+        for pattern in list(getattr(cfg, "cli_patterns", ()) or ()):
+            argv.extend(["--ignore", str(pattern)])
+
+    proc = subprocess.Popen(
+        argv,
+        cwd=str(get_repo_root()),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+    deadline = time.time() + float(timeout_s)
+    attempts = 0
+    last_error: str | None = None
+    while time.time() < deadline:
+        attempts += 1
+        try:
+            res = query_daemon(repo_root, {"cmd": "ping"}, index_ctx=index_ctx)
+            if res.get("status") == "ok":
+                return {"ok": True, "attempts": attempts, "pid": proc.pid}
+            last_error = str(res.get("message") or "status!=ok")
+        except Exception as exc:
+            last_error = f"{type(exc).__name__}: {exc}"
+        time.sleep(0.05)
+    try:
+        proc.terminate()
+    except Exception:
+        pass
+    return {
+        "ok": False,
+        "attempts": attempts,
+        "last_error": last_error,
+        "pid": proc.pid,
+        "returncode": proc.poll(),
+    }
+
+
+def stop_benchmark_daemon(repo_root: Path, *, index_ctx: Any) -> None:
+    from tldr.daemon.startup import stop_daemon
+
+    try:
+        stop_daemon(repo_root, index_ctx=index_ctx)
+    except Exception:
+        pass
+
+
+def query_daemon_ok(
+    repo_root: Path,
+    *,
+    index_ctx: Any,
+    command: dict[str, Any],
+) -> dict[str, Any]:
+    from tldr.daemon.startup import query_daemon
+
+    res = query_daemon(repo_root, command, index_ctx=index_ctx)
+    if res.get("status") != "ok":
+        raise RuntimeError(str(res.get("message") or res.get("error") or res))
+    return res

--- a/tests/test_bench_structured_retrieval_helpers.py
+++ b/tests/test_bench_structured_retrieval_helpers.py
@@ -1,0 +1,259 @@
+import json
+import runpy
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _load_mod():
+    scripts_dir = (Path(__file__).resolve().parents[1] / "scripts").as_posix()
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+    return runpy.run_path("scripts/bench_structured_retrieval.py")
+
+
+def test_score_structured_predictions_matches_rg_span_to_gold_symbol():
+    mod = _load_mod()
+    score = mod["_score_structured_predictions"]
+
+    result = score(
+        targets=[
+            {
+                "file": "pkg/mod.py",
+                "qualified_symbol": "pkg.mod.py.Target",
+                "symbol_kind": "class",
+                "start_line": 20,
+                "end_line": 20,
+            }
+        ],
+        predictions=[
+            {
+                "file": "pkg/mod.py",
+                "qualified_symbol": None,
+                "symbol_kind": "unknown",
+                "start_line": 20,
+                "end_line": 20,
+                "rank": 1,
+            }
+        ],
+    )
+
+    assert result["tp"] == 1
+    assert result["fp"] == 0
+    assert result["fn"] == 0
+    assert result["matched_pairs"][0]["mode"] == "span"
+
+
+def test_score_structured_predictions_rejects_wrong_symbol_when_both_sides_have_symbols():
+    mod = _load_mod()
+    score = mod["_score_structured_predictions"]
+
+    result = score(
+        targets=[
+            {
+                "file": "pkg/mod.py",
+                "qualified_symbol": "pkg.mod.py.Target",
+                "symbol_kind": "class",
+                "start_line": 20,
+                "end_line": 20,
+            }
+        ],
+        predictions=[
+            {
+                "file": "pkg/mod.py",
+                "qualified_symbol": "pkg.mod.py.OtherTarget",
+                "symbol_kind": "class",
+                "start_line": 20,
+                "end_line": 20,
+                "rank": 1,
+            }
+        ],
+    )
+
+    assert result["tp"] == 0
+    assert result["fp"] == 1
+    assert result["fn"] == 1
+    assert result["matched_pairs"] == []
+
+
+def test_dedupe_items_drops_duplicate_symbol_predictions():
+    mod = _load_mod()
+    dedupe = mod["_dedupe_items"]
+
+    items, unscorable = dedupe(
+        [
+            {
+                "file": "pkg/mod.py",
+                "qualified_symbol": "pkg.mod.py.Target",
+                "symbol_kind": "class",
+                "start_line": 20,
+                "end_line": 20,
+                "rank": 1,
+            },
+            {
+                "file": "pkg/mod.py",
+                "qualified_symbol": "pkg.mod.py.Target",
+                "symbol_kind": "class",
+                "start_line": 20,
+                "end_line": 20,
+                "rank": 2,
+            },
+        ]
+    )
+
+    assert unscorable == 0
+    assert len(items) == 1
+
+
+def test_hybrid_structured_predictions_projects_semantic_units_within_ranked_files(tmp_path: Path):
+    mod = _load_mod()
+    hybrid = mod["_hybrid_structured_predictions"]
+    backend = mod["BackendSpec"](
+        backend_id="bge_hybrid",
+        kind="semantic_hybrid",
+        display_name="bge hybrid",
+        projection_unit_k=10,
+    )
+
+    def fake_rows(*_, retrieval_mode: str = "semantic", **__):
+        if retrieval_mode == "hybrid":
+            return [
+                {"file": "pkg/first.py", "rank": 1},
+                {"file": "pkg/second.py", "rank": 2},
+            ]
+        return [
+            {
+                "file": "pkg/second.py",
+                "qualified_name": "pkg.second.py.Second",
+                "unit_type": "class",
+                "line": 20,
+            },
+            {
+                "file": "pkg/first.py",
+                "qualified_name": "pkg.first.py.First",
+                "unit_type": "class",
+                "line": 10,
+            },
+            {
+                "file": "pkg/first.py",
+                "qualified_name": "pkg.first.py.Helper",
+                "unit_type": "class",
+                "line": 30,
+            },
+        ]
+
+    hybrid.__globals__["_semantic_search_rows"] = fake_rows
+
+    predictions = hybrid(
+        tmp_path,
+        backend=backend,
+        query="Where is First implemented?",
+        rg_pattern="First",
+        top_k=2,
+        use_daemon=False,
+    )
+
+    assert [item["qualified_symbol"] for item in predictions] == [
+        "pkg.first.py.First",
+        "pkg.first.py.Helper",
+    ]
+    assert [item["hybrid_file_rank"] for item in predictions] == [1, 1]
+    assert [item["rank"] for item in predictions] == [1, 2]
+
+
+def test_main_writes_backend_micro_f1_report(tmp_path: Path, monkeypatch):
+    mod = _load_mod()
+    main = mod["main"]
+    globals_dict = main.__globals__
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+
+    queries_path = tmp_path / "queries.json"
+    queries_path.write_text(
+        json.dumps(
+            {
+                "queries": [
+                    {
+                        "id": "SR1",
+                        "query": "Where is Target implemented?",
+                        "rg_pattern": "^class\\s+Target\\b",
+                        "targets": [
+                            {
+                                "file": "pkg/mod.py",
+                                "qualified_symbol": "pkg.mod.py.Target",
+                                "symbol_kind": "class",
+                                "start_line": 20,
+                                "end_line": 20,
+                            }
+                        ],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    semantic_meta = tmp_path / "semantic-meta.json"
+    semantic_meta.write_text(json.dumps({"model": "fake-model", "dimension": 128}), encoding="utf-8")
+
+    fake_index_ctx = SimpleNamespace(
+        paths=SimpleNamespace(semantic_metadata=semantic_meta),
+        cache_root=tmp_path / "cache",
+        index_id="repo:test-bge",
+        config=None,
+    )
+
+    monkeypatch.setitem(globals_dict, "get_index_context", lambda **_: fake_index_ctx)
+    monkeypatch.setitem(
+        globals_dict,
+        "_rg_structured_predictions",
+        lambda *_, **__: [
+            {
+                "file": "pkg/mod.py",
+                "qualified_symbol": None,
+                "symbol_kind": "unknown",
+                "start_line": 20,
+                "end_line": 20,
+                "rank": 1,
+            }
+        ],
+    )
+    monkeypatch.setitem(
+        globals_dict,
+        "_semantic_structured_predictions",
+        lambda *_, **__: [
+            {
+                "file": "pkg/mod.py",
+                "qualified_symbol": "pkg.mod.py.Target",
+                "symbol_kind": "class",
+                "start_line": 20,
+                "end_line": 20,
+                "rank": 1,
+            }
+        ],
+    )
+
+    out_path = tmp_path / "report.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "bench_structured_retrieval.py",
+            "--repo-root",
+            str(repo_root),
+            "--queries",
+            str(queries_path),
+            "--semantic-backend",
+            "bge=repo:test-bge",
+            "--out",
+            str(out_path),
+        ],
+    )
+
+    assert main() == 0
+
+    report = json.loads(out_path.read_text(encoding="utf-8"))
+    assert report["results"]["by_backend"]["rg_native"]["micro"]["f1"] == 1.0
+    assert report["results"]["by_backend"]["bge"]["micro"]["f1"] == 1.0
+    assert report["results"]["comparisons"][0]["lhs"] == "bge"

--- a/tests/test_cli_semantic_model_flags.py
+++ b/tests/test_cli_semantic_model_flags.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import argparse
+
+from tldr.cli import build_parser
+
+
+def _semantic_index_parser() -> argparse.ArgumentParser:
+    parser = build_parser()
+    root_subparsers = next(
+        action
+        for action in parser._actions
+        if isinstance(action, argparse._SubParsersAction)
+    )
+    semantic_parser = root_subparsers.choices["semantic"]
+    semantic_subparsers = next(
+        action
+        for action in semantic_parser._actions
+        if isinstance(action, argparse._SubParsersAction)
+    )
+    return semantic_subparsers.choices["index"]
+
+
+def test_semantic_index_model_flag_accepts_jina() -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        ["semantic", "index", ".", "--model", "jina-code-0.5b"]
+    )
+
+    assert args.command == "semantic"
+    assert args.action == "index"
+    assert args.model == "jina-code-0.5b"
+
+
+def test_semantic_index_help_mentions_jina() -> None:
+    help_text = _semantic_index_parser().format_help()
+    normalized = help_text.replace("-\n                        ", "-")
+    assert "jina-code-0.5b" in normalized

--- a/tests/test_daemon_semantic_model_config.py
+++ b/tests/test_daemon_semantic_model_config.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from tldr.daemon.core import TLDRDaemon
+
+
+def test_load_semantic_config_accepts_jina_model(tmp_path) -> None:
+    tldr_config = tmp_path / "config.json"
+    tldr_config.write_text(json.dumps({"semantic": {"model": "jina-code-0.5b"}}))
+
+    dummy = SimpleNamespace(
+        _claude_settings_path=tmp_path / "settings.json",
+        _tldr_config_path=tldr_config,
+    )
+
+    config = TLDRDaemon._load_semantic_config(dummy)
+
+    assert config["model"] == "jina-code-0.5b"
+
+
+def test_load_semantic_config_keeps_bge_default(tmp_path) -> None:
+    dummy = SimpleNamespace(
+        _claude_settings_path=tmp_path / "settings.json",
+        _tldr_config_path=tmp_path / "config.json",
+    )
+
+    config = TLDRDaemon._load_semantic_config(dummy)
+
+    assert config["model"] == "bge-large-en-v1.5"
+
+
+def test_daemon_semantic_index_uses_configured_model(monkeypatch, tmp_path) -> None:
+    import tldr.semantic as semantic
+
+    captured = {}
+
+    def _fake_build_semantic_index(project_path, **kwargs):
+        captured["project_path"] = project_path
+        captured.update(kwargs)
+        return 7
+
+    monkeypatch.setattr(semantic, "build_semantic_index", _fake_build_semantic_index)
+
+    dummy = SimpleNamespace(
+        project=tmp_path,
+        _semantic_config={"model": "jina-code-0.5b"},
+        _ignore_spec=None,
+        index_paths=None,
+        index_config=None,
+        _workspace_root=None,
+    )
+
+    out = TLDRDaemon._handle_semantic(
+        dummy,
+        {"action": "index", "language": "python"},
+    )
+
+    assert out == {"status": "ok", "indexed": 7}
+    assert captured["project_path"] == str(tmp_path)
+    assert captured["lang"] == "python"
+    assert captured["model"] == "jina-code-0.5b"

--- a/tests/test_semantic_index_isolated.py
+++ b/tests/test_semantic_index_isolated.py
@@ -1,3 +1,5 @@
+import json
+
 import numpy as np
 import pytest
 
@@ -6,10 +8,13 @@ from tldr.semantic import build_semantic_index, semantic_search
 
 
 class DummyModel:
+    def __init__(self, dim: int = 3):
+        self.dim = dim
+
     def encode(self, texts, batch_size=None, normalize_embeddings=True, show_progress_bar=False):
         if isinstance(texts, str):
             texts = [texts]
-        return np.zeros((len(texts), 3), dtype=np.float32)
+        return np.zeros((len(texts), self.dim), dtype=np.float32)
 
 
 def test_semantic_indexes_isolated(tmp_path, monkeypatch):
@@ -136,3 +141,37 @@ def test_semantic_search_scoped_to_index(tmp_path, monkeypatch):
     )
     assert repo_results
     assert all("repo.py" in r.get("file", "") for r in repo_results)
+
+
+def test_semantic_metadata_tracks_actual_embedding_dimension_for_jina(
+    tmp_path, monkeypatch
+):
+    pytest.importorskip("faiss")
+    scan_root = tmp_path / "jina_repo"
+    scan_root.mkdir()
+    (scan_root / "auth.py").write_text("def verify_access_token(token):\n    return token\n")
+
+    monkeypatch.setattr(
+        "tldr.semantic.get_model",
+        lambda *_args, **_kwargs: DummyModel(dim=896),
+    )
+
+    build_semantic_index(
+        str(scan_root),
+        lang="python",
+        model="jina-code-0.5b",
+        show_progress=False,
+    )
+
+    metadata = json.loads(
+        (scan_root / ".tldr" / "cache" / "semantic" / "metadata.json").read_text()
+    )
+    assert metadata["model"] == "jinaai/jina-code-embeddings-0.5b"
+    assert metadata["dimension"] == 896
+
+    results = semantic_search(
+        str(scan_root),
+        "verify token",
+        model="jina-code-0.5b",
+    )
+    assert results

--- a/tests/test_semantic_index_rebuild_guards.py
+++ b/tests/test_semantic_index_rebuild_guards.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from tldr.semantic import build_semantic_index, semantic_search
+
+
+class DummyModel:
+    def __init__(self, dim: int):
+        self.dim = dim
+
+    def encode(
+        self,
+        texts,
+        batch_size=None,
+        normalize_embeddings=True,
+        show_progress_bar=False,
+    ):
+        if isinstance(texts, str):
+            texts = [texts]
+        return np.zeros((len(texts), self.dim), dtype=np.float32)
+
+
+def _make_repo(tmp_path):
+    scan_root = tmp_path / "repo"
+    scan_root.mkdir()
+    (scan_root / "auth.py").write_text("def verify_access_token(token):\n    return token\n")
+    return scan_root
+
+
+def test_switching_to_jina_requires_rebuild(tmp_path, monkeypatch) -> None:
+    pytest.importorskip("faiss")
+    scan_root = _make_repo(tmp_path)
+
+    monkeypatch.setattr(
+        "tldr.semantic.get_model",
+        lambda model_name=None, **_kwargs: DummyModel(
+            896 if model_name == "jina-code-0.5b" else 1024
+        ),
+    )
+
+    build_semantic_index(
+        str(scan_root),
+        lang="python",
+        model="bge-large-en-v1.5",
+        show_progress=False,
+    )
+
+    with pytest.raises(ValueError, match="Semantic index model mismatch"):
+        build_semantic_index(
+            str(scan_root),
+            lang="python",
+            model="jina-code-0.5b",
+            show_progress=False,
+        )
+
+
+def test_searching_with_jina_against_bge_index_raises_model_mismatch(
+    tmp_path, monkeypatch
+) -> None:
+    pytest.importorskip("faiss")
+    scan_root = _make_repo(tmp_path)
+
+    monkeypatch.setattr(
+        "tldr.semantic.get_model",
+        lambda model_name=None, **_kwargs: DummyModel(
+            896 if model_name == "jina-code-0.5b" else 1024
+        ),
+    )
+
+    build_semantic_index(
+        str(scan_root),
+        lang="python",
+        model="bge-large-en-v1.5",
+        show_progress=False,
+    )
+
+    with pytest.raises(
+        ValueError, match="Semantic search model mismatch with index"
+    ):
+        semantic_search(
+            str(scan_root),
+            "find jwt validation",
+            model="jina-code-0.5b",
+        )

--- a/tests/test_semantic_instruction_routing.py
+++ b/tests/test_semantic_instruction_routing.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from tldr.semantic import (
+    EmbeddingUnit,
+    build_document_embedding_text,
+    build_embedding_text,
+    build_query_embedding_text,
+)
+
+
+def _unit() -> EmbeddingUnit:
+    return EmbeddingUnit(
+        name="verify_access_token",
+        qualified_name="auth.verify_access_token",
+        file="auth.py",
+        line=1,
+        language="python",
+        unit_type="function",
+        signature="def verify_access_token(token: str) -> dict",
+        docstring="Validate a JWT and return claims.",
+        code_preview="claims = decode(token)\nreturn claims",
+    )
+
+
+def test_jina_document_embedding_uses_candidate_prefix() -> None:
+    text = build_document_embedding_text(_unit(), "jina-code-0.5b")
+    assert text.startswith("Candidate code snippet:\n")
+    assert "Function: verify_access_token" in text
+
+
+def test_jina_query_embedding_uses_nl2code_prefix() -> None:
+    assert (
+        build_query_embedding_text("find jwt validation", "jina-code-0.5b")
+        == "Find the most relevant code snippet given the following query:\n"
+        "find jwt validation"
+    )
+
+
+def test_bge_query_embedding_keeps_existing_prefix() -> None:
+    assert (
+        build_query_embedding_text("find jwt validation", "bge-large-en-v1.5")
+        == "Represent this code search query: find jwt validation"
+    )
+
+
+def test_bge_document_embedding_remains_unprefixed() -> None:
+    unit = _unit()
+    assert build_document_embedding_text(unit, "bge-large-en-v1.5") == build_embedding_text(unit)

--- a/tests/test_semantic_model_loading.py
+++ b/tests/test_semantic_model_loading.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import pytest
+
+from tldr import semantic
+
+
+class FakeSentenceTransformer:
+    instances = []
+
+    def __init__(self, model_name, **kwargs):
+        self.model_name = model_name
+        self.kwargs = kwargs
+        FakeSentenceTransformer.instances.append(self)
+
+    def encode(
+        self,
+        texts,
+        batch_size=None,
+        normalize_embeddings=True,
+        show_progress_bar=False,
+    ):
+        if isinstance(texts, str):
+            texts = [texts]
+        return [[0.0, 0.0, 0.0] for _ in texts]
+
+
+@pytest.fixture(autouse=True)
+def reset_model_cache() -> None:
+    semantic._reset_cached_model()
+    try:
+        yield
+    finally:
+        semantic._reset_cached_model()
+
+
+def test_jina_loading_uses_left_padding(monkeypatch) -> None:
+    import sentence_transformers
+
+    FakeSentenceTransformer.instances.clear()
+    semantic._reset_cached_model()
+    monkeypatch.setattr(semantic, "_model_exists_locally", lambda _hf_name: True)
+    monkeypatch.setattr(
+        sentence_transformers, "SentenceTransformer", FakeSentenceTransformer
+    )
+
+    model = semantic.get_model("jina-code-0.5b", device="cpu")
+
+    assert model is FakeSentenceTransformer.instances[0]
+    assert model.model_name == "jinaai/jina-code-embeddings-0.5b"
+    assert model.kwargs["device"] == "cpu"
+    assert model.kwargs["tokenizer_kwargs"] == {"padding_side": "left"}
+
+
+def test_bge_and_minilm_do_not_force_left_padding(monkeypatch) -> None:
+    import sentence_transformers
+
+    FakeSentenceTransformer.instances.clear()
+    semantic._reset_cached_model()
+    monkeypatch.setattr(semantic, "_model_exists_locally", lambda _hf_name: True)
+    monkeypatch.setattr(
+        sentence_transformers, "SentenceTransformer", FakeSentenceTransformer
+    )
+
+    semantic.get_model("bge-large-en-v1.5", device="cpu")
+    semantic._reset_cached_model()
+    semantic.get_model("all-MiniLM-L6-v2", device="cpu")
+
+    assert len(FakeSentenceTransformer.instances) == 2
+    assert "tokenizer_kwargs" not in FakeSentenceTransformer.instances[0].kwargs
+    assert "tokenizer_kwargs" not in FakeSentenceTransformer.instances[1].kwargs
+
+
+def test_model_cache_invalidates_when_model_or_device_changes(monkeypatch) -> None:
+    import sentence_transformers
+
+    FakeSentenceTransformer.instances.clear()
+    semantic._reset_cached_model()
+    monkeypatch.setattr(semantic, "_model_exists_locally", lambda _hf_name: True)
+    monkeypatch.setattr(
+        sentence_transformers, "SentenceTransformer", FakeSentenceTransformer
+    )
+
+    first = semantic.get_model("jina-code-0.5b", device="cpu")
+    second = semantic.get_model("jina-code-0.5b", device="cpu")
+    third = semantic.get_model("jina-code-0.5b", device="mps")
+    fourth = semantic.get_model("bge-large-en-v1.5", device="mps")
+
+    assert first is second
+    assert first is not third
+    assert third is not fourth
+    assert len(FakeSentenceTransformer.instances) == 3

--- a/tests/test_semantic_model_profiles.py
+++ b/tests/test_semantic_model_profiles.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from tldr.semantic import SUPPORTED_MODELS
+
+
+def test_jina_code_profile_is_registered() -> None:
+    profile = SUPPORTED_MODELS["jina-code-0.5b"]
+
+    assert profile["hf_name"] == "jinaai/jina-code-embeddings-0.5b"
+    assert profile["dimension"] == 896
+    assert (
+        profile["query_prefix"]
+        == "Find the most relevant code snippet given the following query:\n"
+    )
+    assert profile["document_prefix"] == "Candidate code snippet:\n"
+    assert profile["tokenizer_kwargs"]["padding_side"] == "left"

--- a/tests/test_semantic_model_registry_helpers.py
+++ b/tests/test_semantic_model_registry_helpers.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from tldr.semantic import (
+    _canonical_model_id,
+    _model_dimension,
+    _query_prefix_for_model,
+    _resolve_hf_model_name,
+)
+
+
+def test_model_registry_helpers_round_trip_supported_keys_and_hf_ids() -> None:
+    jina_hf = "jinaai/jina-code-embeddings-0.5b"
+
+    assert _resolve_hf_model_name("jina-code-0.5b") == jina_hf
+    assert _canonical_model_id("jina-code-0.5b") == jina_hf
+    assert _canonical_model_id(jina_hf) == jina_hf
+    assert _model_dimension("jina-code-0.5b") == 896
+
+
+def test_bge_registry_contract_remains_unchanged() -> None:
+    assert _resolve_hf_model_name("bge-large-en-v1.5") == "BAAI/bge-large-en-v1.5"
+    assert _canonical_model_id("bge-large-en-v1.5") == "BAAI/bge-large-en-v1.5"
+    assert _model_dimension("bge-large-en-v1.5") == 1024
+    assert (
+        _query_prefix_for_model("bge-large-en-v1.5")
+        == "Represent this code search query: "
+    )

--- a/tests/test_typescript_semantic.py
+++ b/tests/test_typescript_semantic.py
@@ -11,6 +11,7 @@ Run with:
 import pytest
 import json
 from pathlib import Path
+import numpy as np
 
 
 # Sample TypeScript code with clear control flow and data flow
@@ -134,9 +135,25 @@ function transform(data) {
 class TestSemanticIndexIntegration:
     """Test that semantic index includes CFG/DFG for TypeScript functions."""
 
-    def test_semantic_index_has_cfg_dfg(self, temp_ts_project):
+    def test_semantic_index_has_cfg_dfg(self, temp_ts_project, monkeypatch):
         """Semantic index metadata should include cfg_summary and dfg_summary."""
         from tldr.semantic import build_semantic_index
+
+        pytest.importorskip("faiss")
+
+        class DummyModel:
+            def encode(
+                self,
+                texts,
+                batch_size=None,
+                normalize_embeddings=True,
+                show_progress_bar=False,
+            ):
+                if isinstance(texts, str):
+                    texts = [texts]
+                return np.zeros((len(texts), 3), dtype=np.float32)
+
+        monkeypatch.setattr("tldr.semantic.get_model", lambda *_args, **_kwargs: DummyModel())
 
         # Build the semantic index
         build_semantic_index(temp_ts_project, lang="typescript", show_progress=False)

--- a/tldr/cli.py
+++ b/tldr/cli.py
@@ -205,7 +205,8 @@ Daemon:
 
 Semantic Search:
     First run downloads embedding model (1.3GB default).
-    Use --model all-MiniLM-L6-v2 for smaller 80MB model.
+    Supported models: bge-large-en-v1.5 (default), jina-code-0.5b (opt-in), all-MiniLM-L6-v2.
+    Switching models requires rebuilding the semantic index.
     Set TLDR_AUTO_DOWNLOAD=1 to skip download prompts.
 
 Device Selection:
@@ -501,7 +502,11 @@ Device Selection:
     index_p.add_argument(
         "--model",
         default=None,
-        help="Embedding model: bge-large-en-v1.5 (1.3GB, default) or all-MiniLM-L6-v2 (80MB)",
+        help=(
+            "Embedding model: bge-large-en-v1.5 (default), "
+            "jina-code-0.5b (opt-in, requires rebuild), or "
+            "all-MiniLM-L6-v2 (lightweight)"
+        ),
     )
     index_p.add_argument(
         "--device",
@@ -662,7 +667,10 @@ Device Selection:
     search_p.add_argument(
         "--model",
         default=None,
-        help="Embedding model (uses index model if not specified)",
+        help=(
+            "Embedding model override. Supports bge-large-en-v1.5, "
+            "jina-code-0.5b, or all-MiniLM-L6-v2; must match the built index."
+        ),
     )
     search_p.add_argument(
         "--device",

--- a/tldr/daemon/core.py
+++ b/tldr/daemon/core.py
@@ -180,7 +180,7 @@ class TLDRDaemon:
         default_config = {
             "enabled": True,
             "auto_reindex_threshold": 20,  # Files changed before auto re-index
-            "model": "bge-large-en-v1.5",
+            "model": "bge-large-en-v1.5",  # Opt-in alternatives include jina-code-0.5b
             "abstain_threshold": None,
             "abstain_empty": False,
             "rerank": False,
@@ -840,9 +840,11 @@ class TLDRDaemon:
 
             if action == "index":
                 language = command.get("language", "python")
+                model = command.get("model", self._semantic_config.get("model"))
                 count = build_semantic_index(
                     str(self.project),
                     lang=language,
+                    model=model if isinstance(model, str) and model.strip() else None,
                     ignore_spec=self._ignore_spec,
                     index_paths=self.index_paths,
                     index_config=self.index_config,
@@ -946,11 +948,15 @@ class TLDRDaemon:
                     "cluster_label_mode",
                     self._semantic_config.get("cluster_label_mode", "auto"),
                 )
+                model_override = command.get("model")
+                if not isinstance(model_override, str) or not model_override.strip():
+                    model_override = None
                 if navigate_cluster:
                     result = semantic_navigation_cluster_search(
                         str(self.project),
                         query,
                         k=k,
+                        model=model_override,
                         retrieval_mode=str(retrieval_mode),
                         no_result_guard=str(no_result_guard),
                         rg_pattern=rg_pattern if isinstance(rg_pattern, str) else None,
@@ -984,6 +990,7 @@ class TLDRDaemon:
                         str(self.project),
                         query,
                         k=k,
+                        model=model_override,
                         retrieval_mode=str(retrieval_mode),
                         no_result_guard=str(no_result_guard),
                         rg_pattern=rg_pattern if isinstance(rg_pattern, str) else None,
@@ -1018,6 +1025,7 @@ class TLDRDaemon:
                     str(self.project),
                     query,
                     k=k,
+                    model=model_override,
                     retrieval_mode=str(retrieval_mode),
                     no_result_guard=str(no_result_guard),
                     rg_pattern=rg_pattern if isinstance(rg_pattern, str) else None,

--- a/tldr/semantic.py
+++ b/tldr/semantic.py
@@ -8,8 +8,7 @@ Embeds functions/methods using all 5 TLDR analysis layers:
 - L4: Data flow summary
 - L5: Dependencies
 
-Uses BAAI/bge-large-en-v1.5 for embeddings (1024 dimensions)
-and FAISS for fast vector similarity search.
+Supports multiple embedding backends and stores vectors in FAISS.
 """
 
 import json
@@ -40,6 +39,7 @@ if sys.platform == "darwin":
 _model = None
 _model_name = None  # Track which model is loaded
 _model_device = None  # Track device used for cached model
+_model_load_kwargs = None  # Track model-specific loader kwargs
 
 # Supported models with approximate download sizes
 SUPPORTED_MODELS = {
@@ -48,12 +48,27 @@ SUPPORTED_MODELS = {
         "size": "1.3GB",
         "dimension": 1024,
         "description": "High quality, recommended for production",
+        "query_prefix": "Represent this code search query: ",
+        "document_prefix": "",
+        "tokenizer_kwargs": {},
     },
     "all-MiniLM-L6-v2": {
         "hf_name": "sentence-transformers/all-MiniLM-L6-v2",
         "size": "80MB",
         "dimension": 384,
         "description": "Lightweight, good for testing",
+        "query_prefix": "",
+        "document_prefix": "",
+        "tokenizer_kwargs": {},
+    },
+    "jina-code-0.5b": {
+        "hf_name": "jinaai/jina-code-embeddings-0.5b",
+        "size": "approx 1GB",
+        "dimension": 896,
+        "description": "Code-specialized, opt-in, non-commercial license by default",
+        "query_prefix": "Find the most relevant code snippet given the following query:\n",
+        "document_prefix": "Candidate code snippet:\n",
+        "tokenizer_kwargs": {"padding_side": "left"},
     },
 }
 
@@ -211,11 +226,25 @@ class EmbeddingUnit:
 MODEL_NAME = "BAAI/bge-large-en-v1.5"  # Legacy, use SUPPORTED_MODELS
 
 
-def _resolve_hf_model_name(model_name: Optional[str]) -> str:
+def _model_profile(model_name: Optional[str]) -> Optional[dict[str, Any]]:
     if model_name is None:
         model_name = DEFAULT_MODEL
     if model_name in SUPPORTED_MODELS:
-        return SUPPORTED_MODELS[model_name]["hf_name"]
+        return SUPPORTED_MODELS[model_name]
+
+    canonical = _canonical_model_id(model_name)
+    for info in SUPPORTED_MODELS.values():
+        if info["hf_name"] == canonical:
+            return info
+    return None
+
+
+def _resolve_hf_model_name(model_name: Optional[str]) -> str:
+    profile = _model_profile(model_name)
+    if profile is not None:
+        return profile["hf_name"]
+    if model_name is None:
+        return SUPPORTED_MODELS[DEFAULT_MODEL]["hf_name"]
     return model_name
 
 
@@ -231,13 +260,37 @@ def _canonical_model_id(model_name: Optional[str]) -> Optional[str]:
 
 
 def _model_dimension(model_name: Optional[str]) -> Optional[int]:
-    canonical = _canonical_model_id(model_name)
-    if canonical is None:
+    profile = _model_profile(model_name)
+    if profile is None:
         return None
-    for info in SUPPORTED_MODELS.values():
-        if info["hf_name"] == canonical:
-            return info["dimension"]
-    return None
+    return profile["dimension"]
+
+
+def _query_prefix_for_model(model_name: Optional[str]) -> str:
+    profile = _model_profile(model_name)
+    if profile is None:
+        return ""
+    return str(profile.get("query_prefix", ""))
+
+
+def _document_prefix_for_model(model_name: Optional[str]) -> str:
+    profile = _model_profile(model_name)
+    if profile is None:
+        return ""
+    return str(profile.get("document_prefix", ""))
+
+
+def _sentence_transformer_kwargs_for_model(
+    model_name: Optional[str],
+) -> dict[str, Any]:
+    profile = _model_profile(model_name)
+    if profile is None:
+        return {}
+
+    tokenizer_kwargs = dict(profile.get("tokenizer_kwargs") or {})
+    if not tokenizer_kwargs:
+        return {}
+    return {"tokenizer_kwargs": tokenizer_kwargs}
 
 
 def _model_exists_locally(hf_name: str) -> bool:
@@ -253,7 +306,7 @@ def _model_exists_locally(hf_name: str) -> bool:
 
 def _confirm_download(model_key: str) -> bool:
     """Prompt user to confirm model download. Returns True if confirmed."""
-    model_info = SUPPORTED_MODELS.get(model_key, {})
+    model_info = _model_profile(model_key) or {}
     size = model_info.get("size", "unknown size")
     hf_name = model_info.get("hf_name", model_key)
 
@@ -308,33 +361,48 @@ def get_model(model_name: Optional[str] = None, device: Optional[str] = None):
     Raises:
         ValueError: If model not found or user declines download.
     """
-    global _model, _model_name, _model_device
+    global _model, _model_name, _model_device, _model_load_kwargs
 
     # Resolve model name
     hf_name = _resolve_hf_model_name(model_name)
+    load_kwargs = _sentence_transformer_kwargs_for_model(model_name)
 
     if device is None:
         device = _get_device()
 
     # Return cached model if same
-    if _model is not None and _model_name == hf_name and _model_device == device:
+    if (
+        _model is not None
+        and _model_name == hf_name
+        and _model_device == device
+        and _model_load_kwargs == load_kwargs
+    ):
         return _model
 
     # Check if model needs downloading
     if not _model_exists_locally(hf_name):
-        model_key = model_name if model_name in SUPPORTED_MODELS else None
+        model_key = model_name if _model_profile(model_name) is not None else None
         if model_key and not _confirm_download(model_key):
             raise ValueError("Model download declined. Use --model to choose a smaller model.")
 
     logger.info("Loading model %s on device: %s", hf_name, device)
     from sentence_transformers import SentenceTransformer
+    sentence_transformer_kwargs = dict(load_kwargs)
     if device:
-        _model = SentenceTransformer(hf_name, device=device)
-    else:
-        _model = SentenceTransformer(hf_name)
+        sentence_transformer_kwargs["device"] = device
+    _model = SentenceTransformer(hf_name, **sentence_transformer_kwargs)
     _model_name = hf_name
     _model_device = device
+    _model_load_kwargs = load_kwargs
     return _model
+
+
+def _reset_cached_model() -> None:
+    global _model, _model_name, _model_device, _model_load_kwargs
+    _model = None
+    _model_name = None
+    _model_device = None
+    _model_load_kwargs = None
 
 
 def build_embedding_text(unit: EmbeddingUnit) -> str:
@@ -388,6 +456,23 @@ def build_embedding_text(unit: EmbeddingUnit) -> str:
     parts.insert(0, f"{type_str.capitalize()}: {unit.name}")
 
     return "\n".join(parts)
+
+
+def build_document_embedding_text(
+    unit: EmbeddingUnit,
+    model_name: Optional[str] = None,
+) -> str:
+    text = build_embedding_text(unit)
+    prefix = _document_prefix_for_model(model_name)
+    return f"{prefix}{text}" if prefix else text
+
+
+def build_query_embedding_text(
+    query: str,
+    model_name: Optional[str] = None,
+) -> str:
+    prefix = _query_prefix_for_model(model_name)
+    return f"{prefix}{query}" if prefix else query
 
 
 def compute_embedding(text: str, model_name: Optional[str] = None, device: Optional[str] = None):
@@ -1274,7 +1359,7 @@ def build_semantic_index(
 
     BATCH_SIZE = 64
     num_units = len(units)
-    texts = [build_embedding_text(unit) for unit in units]
+    texts = [build_document_embedding_text(unit, model) for unit in units]
 
     if console:
         from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TaskProgressColumn
@@ -1415,8 +1500,12 @@ def _semantic_unit_search(
                 "Semantic search model mismatch with index. Use the index model or rebuild."
             )
 
-    # Embed query (with instruction prefix for BGE)
-    query_text = f"Represent this code search query: {query}"
+    meta_dim = metadata.get("dimension")
+    expected_dim = _model_dimension(model)
+    if expected_dim and meta_dim and expected_dim != meta_dim:
+        raise ValueError("Semantic model dimension mismatch; rebuild required.")
+
+    query_text = build_query_embedding_text(query, model)
     query_embedding = compute_embedding(query_text, model_name=model, device=device)
     query_embedding = query_embedding.reshape(1, -1)
 
@@ -1425,12 +1514,10 @@ def _semantic_unit_search(
     index = faiss.read_index(str(index_file))
 
     # Validate dimension compatibility
-    meta_dim = metadata.get("dimension")
     if meta_dim and index.d != meta_dim:
         raise ValueError("Semantic index dimension mismatch; rebuild required.")
-    expected_dim = _model_dimension(model)
-    if expected_dim and meta_dim and expected_dim != meta_dim:
-        raise ValueError("Semantic model dimension mismatch; rebuild required.")
+    if query_embedding.shape[1] != index.d:
+        raise ValueError("Semantic query embedding dimension mismatch; rebuild required.")
 
     # Search
     k = min(k, len(units))


### PR DESCRIPTION
## Summary

This PR completes the current `bge-large-en-v1.5` vs `jina-code-0.5b` migration investigation without flipping the product default.

It does three things:

1. Adds opt-in `jina-code-0.5b` support to the semantic stack.
2. Expands the benchmark harness so model comparisons run in daemon mode and can be evaluated on structured retrieval surfaces, not only ranking metrics.
3. Publishes the benchmark-backed operating guidance for when to use `rg-native` vs `tldrf`, and when `BGE` vs `Jina` is the better retrieval backend.

The resulting product decision stays the same:
- Keep `bge-large-en-v1.5` as the default model.
- Keep `jina-code-0.5b` opt-in for semantic-only or budget-limited semantic retrieval.
- Keep `rg-native` as the first tool for exact lexical lookup.

## Why This Exists

The goal was not just to make Jina load. The goal was to determine whether it should replace BGE in the actual product path.

That required more than one benchmark family:
- direct semantic retrieval quality
- token-efficiency retrieval
- daemon-mode latency
- compound semantic + impact behavior
- structured exact-definition retrieval
- structured behavior-oriented retrieval
- documentation that translates those results into actual operator guidance

## What Changed

### 1. Core semantic model support

- Added `jina-code-0.5b` as a supported embedding model.
- Switched the semantic stack from a lightweight model-name map to model profiles with:
  - HF id
  - embedding dimension
  - query prefix
  - document prefix
  - tokenizer kwargs
- Routed query and document embedding text through explicit helpers.
- Added model-specific loader kwargs to the cached SentenceTransformer key.
- Configured Jina with left-padding tokenizer kwargs.
- Threaded model selection through CLI and daemon semantic operations.
- Tightened mismatch detection around index model and dimension compatibility.

Relevant files:
- `tldr/semantic.py`
- `tldr/daemon/core.py`
- `tldr/cli.py`

### 2. Benchmark harness expansion

- Made retrieval, token-efficiency, compound semantic+impact, and perf benchmark runners daemon-aware so model comparisons use the warm-query path that matters in practice.
- Added shared benchmark helpers for starting, querying, and stopping the daemon cleanly.
- Persisted semantic model and dimension provenance in relevant benchmark outputs.
- Added a deterministic structured retrieval benchmark plus two Django suites:
  - exact-definition suite
  - behavior-oriented suite

Relevant files:
- `scripts/bench_retrieval_quality.py`
- `scripts/bench_token_efficiency.py`
- `scripts/bench_perf_daemon_vs_cli.py`
- `scripts/bench_compound_semantic_impact.py`
- `scripts/bench_util.py`
- `scripts/bench_structured_retrieval.py`
- `benchmarks/retrieval/django_structured_queries.json`
- `benchmarks/retrieval/django_structured_behavior_queries.json`

### 3. Tests and regression coverage

Added coverage for:
- model registry/profile behavior
- instruction routing
- loader kwargs and cache invalidation
- CLI model flag support
- daemon semantic model config behavior
- rebuild/model mismatch guards
- Jina dimension persistence in semantic metadata
- structured retrieval helpers
- semantic-index integration isolation in TypeScript tests

### 4. Public-facing docs and benchmark summary

- Added a public model-variant addendum to the benchmark README.
- Added the same-tool BGE vs Jina summary to the 008 operator docs.
- Turned the reference card into a real one-page usage guide.
- Clarified that `docs/usage.md` is the execution-mode doc, not the task-selection doc.
- Recorded the full 009 migration run log, benchmark findings, gotchas, and next steps.

Relevant files:
- `benchmarks/README.md`
- `docs/llm-tldr-reference-card.md`
- `docs/usage.md`
- `README.md`
- `docs/TLDR.md`
- `implementations/008-benchmark-summary.md`
- `implementations/008-beat-contextplus_IMPLEMENTATION_PLAN.md`
- `implementations/008-canonical-matrix-run1-snapshot.md`
- `implementations/009-migrate-bge-to-jina-code-0.5b_IMPLEMENTATION_PLAN.md`

## What The Benchmarks Say

### Where Jina is better

Jina improved pure semantic retrieval quality on the daemon-mode Django runs:
- semantic MRR: `0.6022 -> 0.7023`
- semantic Recall@5: `0.7719 -> 0.8596`
- semantic Recall@10: `0.7895 -> 0.8772`

It also improved semantic-only retrieval under token pressure at `budget=1000`:
- semantic: `0.6124 -> 0.7048`

### Where Jina does not justify replacing BGE

Jina was not better on the broader product path:
- lane2 hybrid MRR regressed: `0.8741 -> 0.8417`
- compound efficiency worsened: `TTE p50 ratio 1.0250 -> 1.1361`
- structured behavior retrieval remained better on BGE
- steady-state daemon semantic latency stayed slower on Jina by about `10-14%`
- Jina build cost remained heavy (`692.57s`, ~`3.36 GB` peak RSS on the Django semantic build)

### Where embeddings should not replace lexical search

Exact structured retrieval is still a lexical problem:
- `rg-native` exact-definition F1: `0.9841`
- BGE exact-definition F1: `0.1602`
- Jina exact-definition F1: `0.1520`

That is why the guidance remains:
- exact lookup -> `rg-native`
- concept lookup + structural follow-up -> `tldrf`

## Validation

Ran after the final fix set:
- `uv run ruff check tldr/ scripts/ tests/`
- `uv run pytest`

Result:
- `ruff` passed on the repo-standard code surface
- `pytest` passed: `624 passed`

Note:
- a broad `uv run ruff check .` is noisy in this worktree because of unrelated scratch files outside the repo-standard lint surface
- pytest still emits a non-blocking coverage warning from the existing `.coverage` database, but it does not fail the suite

## Commit Structure

1. `feat: add opt-in jina semantic model support`
2. `feat: expand daemon benchmark coverage for model comparisons`
3. `docs: publish jina migration guidance and benchmark summary`

## Recommended Next Steps

1. Add end-to-end edit-loop benchmarks that measure time-to-first-correct-edit, token spend, and changed-file recall vs `rg-native`.
2. Add `daemon notify` / freshness benchmarks so the "index once, keep it fresh" story is measured, not inferred.
3. Finish dependency-scoped BGE vs Jina runs (`requests`, `urllib3`) so model guidance is not Django-only.
4. Run a fresh BGE build/RSS parity pass against the same Django benchmark path used for the Jina build-cost measurement.
5. Improve guarded-hybrid evaluation; strict `rg_empty` is currently too aggressive on the behavior-oriented structured suite.
6. Clean up remaining long-form docs/help surfaces that still imply `warm` alone gives semantic setup or that under-explain daemon-first usage.


## Lane 1 vs Lane 2 Guidance

For normal product usage, lane1 should be treated as the practical default.

Why:
- lane1 already gives the main product value: hybrid lexical + semantic retrieval
- once lane1 finds the right code, the real differentiator is the deterministic structural follow-up (`impact`, `context`, `slice`, `dfg`, `cfg`)
- lane2 is still useful as a stricter benchmark/gating surface, but it is not the mode most users need for everyday retrieval

Important nuance:
- even if we treat lane1 as the main retrieval path, that still does **not** justify flipping the default model from BGE to Jina today
- Jina is only marginally better on lane1 hybrid quality
- BGE still looks stronger on the broader product path because it remains better on structured behavior retrieval, compound semantic+impact efficiency, and steady-state daemon latency

So the operational recommendation remains:
- lane1 hybrid retrieval is enough for most real usage
- BGE stays the default model
- Jina remains opt-in for semantic-only and budget-limited semantic retrieval experiments
